### PR TITLE
Allow multiple authorization headers

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -23,7 +23,7 @@
 		"python.linting.pycodestylePath": "/usr/local/py-utils/bin/pycodestyle",
 		"python.linting.pydocstylePath": "/usr/local/py-utils/bin/pydocstyle",
 		"python.linting.pylintPath": "/usr/local/py-utils/bin/pylint",
-		"python.testing.pytestPath": "/usr/local/py-utils/bin/pytest",
+		"python.testing.pytestPath": "/home/vscode/.local/bin/pytest",
 		"python.testing.unittestEnabled": false,
 		"python.testing.pytestEnabled": true,
 		"python.analysis.extraPaths": [
@@ -41,13 +41,10 @@
 	"extensions": [
 		"ms-python.python",
 		"ms-python.vscode-pylance",
-		"mtxr.sqltools",
-		"mtxr.sqltools-driver-pg",
 		"42crunch.vscode-openapi",
 		"eamodio.gitlens",
 		"formulahendry.terminal",
 		"tyriar.terminal-tabs",
-		"alexcvzz.vscode-sqlite",
 		"njpwerner.autodocstring",
 		"arjun.swagger-viewer",
 		"ms-toolsai.jupyter",

--- a/auth_service/auth_adapter/api/headers.py
+++ b/auth_service/auth_adapter/api/headers.py
@@ -19,14 +19,18 @@ Manage request and response headers
 
 from typing import Optional
 
+__all__ = ["get_bearer_token"]
 
-def get_access_token(authorization: Optional[str]) -> Optional[str]:
-    """Extract the access token from the authorization header.
 
-    Return None if no bearer token was passed as authorization header.
+def get_bearer_token(*header_values: Optional[str]) -> Optional[str]:
+    """Extract the bearer token from the authorization header.
+
+    Multiple possible authorization header values can be passed,
+    in case one of them is used for Basic authentication.
+
+    Return None if no bearer token was found in one of the header values.
     """
-    if authorization:
-        authorization_parts = authorization.split(" ", 1)
-        if len(authorization_parts) == 2 and authorization_parts[0] == "Bearer":
-            return authorization_parts[1]
+    for header_value in header_values:
+        if header_value and header_value.startswith("Bearer "):
+            return header_value.removeprefix("Bearer ")
     return None

--- a/auth_service/auth_adapter/api/main.py
+++ b/auth_service/auth_adapter/api/main.py
@@ -27,7 +27,7 @@ from ghga_service_chassis_lib.api import configure_app
 from ...config import CONFIG, configure_logging
 from ..core.auth import exchange_token
 from .basic import basic_auth
-from .headers import get_access_token
+from .headers import get_bearer_token
 
 configure_logging()
 
@@ -48,6 +48,7 @@ async def ext_auth_well_known() -> dict:
 async def ext_auth(
     response: Response,
     authorization: Optional[str] = Header(default=None),
+    x_authorization: Optional[str] = Header(default=None),
     _basic_auth: None = basic_auth(app, config=CONFIG),
 ) -> dict:
     """Implements the ExtAuth protocol to authenticate users in the API gateway.
@@ -56,9 +57,8 @@ async def ext_auth(
     If the access token does not exist or is invalid, no internal token will be placed,
     but the status will still be returned as OK so that all requests can pass.
     """
-    access_token = get_access_token(authorization)
+    access_token = get_bearer_token(authorization, x_authorization)
     internal_token = exchange_token(access_token)
     if internal_token:
-        response.headers[CONFIG.token_name] = internal_token
-    del response.headers["authorization"]
+        response.headers["Authorization"] = internal_token
     return {}

--- a/auth_service/config.py
+++ b/auth_service/config.py
@@ -60,10 +60,9 @@ class Config(ApiConfigBase):
     """Config parameters and their defaults."""
 
     service_name: str = "auth_service"
-    log_level: LogLevel = "info"
+    log_level: LogLevel = "debug"
     run_auth_adapter: bool = False
     auth_path_prefix: str = "/auth"
-    token_name: str = "x-ghga-token"
     basic_auth_user: Optional[str] = None
     basic_auth_pwd: Optional[str] = None
     basic_auth_realm: Optional[str] = "GHGA Data Portal"

--- a/config_schema.json
+++ b/config_schema.json
@@ -159,14 +159,6 @@
       ],
       "type": "string"
     },
-    "token_name": {
-      "title": "Token Name",
-      "default": "x-ghga-token",
-      "env_names": [
-        "auth_service_token_name"
-      ],
-      "type": "string"
-    },
     "basic_auth_user": {
       "title": "Basic Auth User",
       "env_names": [

--- a/example_config.yaml
+++ b/example_config.yaml
@@ -15,5 +15,4 @@ openapi_url: /openapi.json
 port: 8080
 run_auth_adapter: false
 service_name: auth_service
-token_name: x-ghga-token
 workers: 1

--- a/tests/integration/auth_adapter/test_api.py
+++ b/tests/integration/auth_adapter/test_api.py
@@ -24,7 +24,6 @@ from auth_service.auth_adapter.core.auth import (
     sign_and_encode_token,
 )
 from auth_service.auth_adapter.core.jwks import internal_jwk
-from auth_service.config import CONFIG
 
 from ...fixtures import (  # noqa: F401; pylint: disable=unused-import
     fixture_external_key,
@@ -147,13 +146,62 @@ def test_token_exchange(external_key, client):
     assert response.json() == {}
 
     headers = response.headers
-    assert "Authorization" not in headers
-    token_name = CONFIG.token_name
-    assert token_name in headers
-    internal_token = headers[token_name]
+    assert "Authorization" in headers
+    internal_token = headers["Authorization"]
     assert internal_token is not None
     assert isinstance(internal_token, str)
     assert internal_token.count(".", 2)
 
     int_payload = decode_and_verify_token(internal_token, key=internal_jwk)
     assert int_payload == {"name": "Foo Bar", "mail": "foo@bar"}
+
+    assert "X-Authorization" not in headers
+
+
+def test_token_exchange_with_x_token(external_key, client):
+    """Test that the external access token can be passed in separate header."""
+
+    ext_payload = {"name": "Foo Bar", "mail": "foo@bar", "sub": "foo", "iss": "bar"}
+    auth = sign_and_encode_token(ext_payload, key=external_key)
+    auth = f"Bearer {auth}"
+    response = client.get("/some/path", headers={"X-Authorization": auth})
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json() == {}
+
+    headers = response.headers
+    assert "Authorization" in headers
+    internal_token = headers["Authorization"]
+    assert internal_token is not None
+    assert isinstance(internal_token, str)
+    assert internal_token.count(".", 2)
+
+    int_payload = decode_and_verify_token(internal_token, key=internal_jwk)
+    assert int_payload == {"name": "Foo Bar", "mail": "foo@bar"}
+
+    assert "X-Authorization" not in headers
+
+
+def test_external_tokens_are_removed(client):
+    """Test that the external access token is exchanged against an internal token."""
+
+    response = client.get("/some/path", headers={"Authorization": "Bearer invalid"})
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json() == {}
+
+    headers = response.headers
+    assert "Authorization" not in headers
+    assert "X-Authorization" not in headers
+
+    response = client.get(
+        "/some/path",
+        headers={"Authorization": "Basic invalid", "X-Authorization": "Bearer invalid"},
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json() == {}
+
+    headers = response.headers
+    assert "Authorization" not in headers
+    assert "X-Authorization" not in headers

--- a/tests/unit/auth_adapter/test_api.py
+++ b/tests/unit/auth_adapter/test_api.py
@@ -14,11 +14,35 @@
 # limitations under the License.
 #
 
-from auth_service.auth_adapter.api.headers import get_access_token
+"""Unit tests for the auth adapter API"""
+
+from auth_service.auth_adapter.api.headers import get_bearer_token
 
 
-def test_get_access_token():
-    """Test that the access token can be extracted from the header."""
-    assert get_access_token(None) is None
-    assert get_access_token("No Bearer token") is None
-    assert get_access_token("Bearer foo-bar") == "foo-bar"
+def test_get_bearer_token_no_headers():
+    """Test that None is returned when there are no headers."""
+    assert get_bearer_token() is None
+    assert get_bearer_token(None) is None
+    assert get_bearer_token(None, None) is None
+
+
+def test_get_bearer_token_invalid_headers():
+    """Test that None is returned when there are no bearer tokens."""
+    assert get_bearer_token("Basic token") is None
+    assert get_bearer_token("Still not a Bearer token") is None
+    assert get_bearer_token("foo", "bar") is None
+    assert get_bearer_token("Basic token", "Invalid token", "Basic token") is None
+
+
+def test_get_bearer_token_one_header():
+    """Test that bearer token is returned when there is one header."""
+    assert get_bearer_token("Bearer foo-bar") == "foo-bar"
+
+
+def test_get_bearer_token_multiple_header():
+    """Test that first bearer token is returned when there are multiple headers."""
+    assert get_bearer_token("Bearer foo-bar", "Bearer bar-foo") == "foo-bar"
+    assert get_bearer_token(None, "Bearer foo-bar") == "foo-bar"
+    assert get_bearer_token("Bearer foo-bar", None) == "foo-bar"
+    assert get_bearer_token("Bearer foo-bar", "Basic foo:bar") == "foo-bar"
+    assert get_bearer_token("Basic foo:bar", "Bearer foo-bar") == "foo-bar"


### PR DESCRIPTION
Currently we use both Basic HTTP authentication and OIDC authentication.

Therefore, we need two authorization headers, Authorization (Basic) and X-Authorization (OIDC).

The auth adapter now evaluates both of these headers for OIDC authentication: If the Authorization header is used for Basic authentication, then the X-Authorization header will be used.