### PR TITLE
Use new service name everywhere

### DIFF
--- a/.devcontainer/dev_launcher
+++ b/.devcontainer/dev_launcher
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-auth-adapter
+auth-service

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,7 @@
 // https://github.com/microsoft/vscode-dev-containers/tree/v0.177.0/containers/python-3-postgres
 // Update the VARIANT arg in docker-compose.yml to pick a Python version: 3, 3.8, 3.7, 3.6
 {
-	"name": "auth-adapter",
+	"name": "auth-service",
 	"dockerComposeFile": "docker-compose.yml",
 	"service": "app",
 	"workspaceFolder": "/workspace",

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 
-![tests](https://github.com/ghga-de/auth-adapter/actions/workflows/unit_and_int_tests.yaml/badge.svg)
-[![Coverage Status](https://coveralls.io/repos/github/ghga-de/auth-adapter/badge.svg?branch=main)](https://coveralls.io/github/ghga-de/auth-adapter?branch=main)
+![tests](https://github.com/ghga-de/auth-service/actions/workflows/unit_and_int_tests.yaml/badge.svg)
+[![Coverage Status](https://coveralls.io/repos/github/ghga-de/auth-service/badge.svg?branch=main)](https://coveralls.io/github/ghga-de/auth-service?branch=main)
 
 # GHGA Auth Service
 
@@ -29,20 +29,20 @@ A pre-built version is available at [docker hub](https://hub.docker.com/reposito
 
 ```bash
 # Please feel free to choose the version as needed:
-docker pull ghga/auth-adapter:<version>
+docker pull ghga/auth-service:<version>
 ```
 
 Or you can build the container yourself from the [`./Dockerfile`](./Dockerfile):
 ```bash
 # Execute in the repo's root dir:
 # (Please feel free to adapt the name/tag.)
-docker build -t ghga/auth-adapter:<version> .
+docker build -t ghga/auth-service:<version> .
 ```
 
 For production-ready deployment, we recommend using Kubernetes, however, for simple use cases, you could execute th service using docker on a single server:
 ```bash
 # The entrypoint is preconfigured:
-docker run -p 8080:8080 ghga/auth-adapter:<version>
+docker run -p 8080:8080 ghga/auth-service:<version>
 ```
 
 If you prefer not to use containers, you may install the service from source:
@@ -51,7 +51,7 @@ If you prefer not to use containers, you may install the service from source:
 pip install .
 
 # to run the service:
-auth-adapter
+auth-service
 ```
 
 ### Configuration

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,7 @@
 name = auth_service
 version = attr: auth_service.__version__
 description = Authentication service for the GHGA data portal used by the API gateway via the ExtAuth protocol
-url = https://github.com/ghga-de/auth-adapter
+url = https://github.com/ghga-de/auth-service
 long_description = file: README.md
 long_description_content_type = text/markdown; charset=UTF-8
 author = German Human Genome Phenome Archive (GHGA)


### PR DESCRIPTION
We have included the user manager into the "auth-adapter" and renamed the service containing everything to "auth-service". The old service name is still used in some places which need to be adapted.