### PR TITLE
Remove auth_path_prefix config setting

### DIFF
--- a/.devcontainer/.dev_config.yaml
+++ b/.devcontainer/.dev_config.yaml
@@ -1,6 +1,5 @@
 # Please only mention the non-default settings here:
 
-auth_path_prefix: /auth
 auto_reload: true
 db_url: mongodb://mongodb:27017/
 host: 0.0.0.0

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ These two services are described in the following sections. The setting `run_aut
 
 The `auth_adapter` subpackage contains the authentication service used by the API gateway via the ExtAuth protocol.
 
+If a `path_prefix` has been configured for the AuthService in the API gateway, then the `api_root_path` must be set accordingly.
 ## User Management
 
 The `user_management` subpackage contains the user data management service.

--- a/auth_service/auth_adapter/api/main.py
+++ b/auth_service/auth_adapter/api/main.py
@@ -17,6 +17,9 @@
 Module containing the main FastAPI router and (optionally) top-level API endpoints.
 Additional endpoints might be structured in dedicated modules
 (each of them having a sub-router).
+
+Note: If a path_prefix is used for the Emissary AuthService,
+then this must be also specified in the config setting api_root_path.
 """
 
 from typing import Optional

--- a/auth_service/config.py
+++ b/auth_service/config.py
@@ -62,7 +62,6 @@ class Config(ApiConfigBase):
     service_name: str = "auth_service"
     log_level: LogLevel = "debug"
     run_auth_adapter: bool = False
-    auth_path_prefix: str = "/auth"
     basic_auth_user: Optional[str] = None
     basic_auth_pwd: Optional[str] = None
     basic_auth_realm: Optional[str] = "GHGA Data Portal"

--- a/config_schema.json
+++ b/config_schema.json
@@ -151,14 +151,6 @@
       ],
       "type": "boolean"
     },
-    "auth_path_prefix": {
-      "title": "Auth Path Prefix",
-      "default": "/auth",
-      "env_names": [
-        "auth_service_auth_path_prefix"
-      ],
-      "type": "string"
-    },
     "basic_auth_user": {
       "title": "Basic Auth User",
       "env_names": [

--- a/example_config.yaml
+++ b/example_config.yaml
@@ -1,5 +1,4 @@
 api_root_path: /
-auth_path_prefix: /auth
 auto_reload: true
 basic_auth_pwd: null
 basic_auth_realm: GHGA Data Portal


### PR DESCRIPTION
The `auth_path_prefix` setting was used to speficy the `path_prefix` that was configured for the auth adapter as an Emissary AuthService. However, adding this prefix can also be achieved by using the already existing setting `api_root_path` for the auth adapter. So that additional setting is not needed. And it was not used so far, anyway.