### PR TITLE
Let auth adapter run without signing keys

### DIFF
--- a/auth_service/auth_adapter/core/auth.py
+++ b/auth_service/auth_adapter/core/auth.py
@@ -37,7 +37,6 @@ class SigningKeys:
 
     def __init__(self, config: Config = CONFIG) -> None:
         """Load all the signing keys from the configuration."""
-        self.valid = True
         external_keys = config.auth_ext_keys
         try:
             if not external_keys:

--- a/auth_service/auth_adapter/core/auth.py
+++ b/auth_service/auth_adapter/core/auth.py
@@ -32,26 +32,30 @@ log = logging.getLogger(__name__)
 class SigningKeys:
     """A container for external and internal signing keys."""
 
-    external_jwks: jwk.JWKSet  # the external public key set
-    internal_jwk: jwk.JWK  # the interal key pair
+    external_jwks: Optional[jwk.JWKSet] = None  # the external public key set
+    internal_jwk: Optional[jwk.JWK] = None  # the internal key pair
 
     def __init__(self, config: Config = CONFIG) -> None:
         """Load all the signing keys from the configuration."""
+        self.valid = True
         external_keys = config.auth_ext_keys
-        if not external_keys:
-            raise RuntimeError("No external signing keys configured.")
         try:
+            if not external_keys:
+                raise ValueError("No external keys configured")
             self.external_jwks = jwk.JWKSet.from_json(external_keys)
-        except Exception as exc:
-            raise RuntimeError("Cannot parse external signing keys.") from exc
+        except Exception as exc:  # pylint:disable=broad-except
+            # do not throw an error so that the auth adapter can still run
+            # even though it will not be able to validate external tokens
+            log.error("Error in external signing keys: %s", exc)
         internal_keys = config.auth_int_keys
-        if not internal_keys:
-            raise RuntimeError("No internal signing keys configured.")
         try:
-            internal_keys = config.auth_int_keys
-        except Exception as exc:
-            raise RuntimeError("Cannot parse internal signing key pair.") from exc
-        self.internal_jwk = jwk.JWK.from_json(internal_keys)
+            if not internal_keys:
+                raise ValueError("No internal signing keys configured.")
+            self.internal_jwk = jwk.JWK.from_json(internal_keys)
+        except Exception as exc:  # pylint:disable=broad-except
+            # do not throw an error so that the auth adapter can still run
+            # even though it will not be able to sign internal tokens
+            log.error("Error in internal signing key pair: %s", exc)
 
 
 signing_keys = SigningKeys()
@@ -84,6 +88,9 @@ def decode_and_verify_token(
         return None
     if not key:
         key = signing_keys.external_jwks
+        if not key:
+            log.debug("No external signing key, cannot verify token")
+            return None
     jws_token = jws.JWS()
     try:
         jws_token.deserialize(access_token, key=key)
@@ -111,6 +118,9 @@ def sign_and_encode_token(payload: dict[str, Any], key=None) -> Optional[str]:
         return None
     if not key:
         key = signing_keys.internal_jwk
+        if not key:
+            log.debug("No internal signing key, cannot sign token")
+            return None
     try:
         jws_token = jws.JWS(json.dumps(payload).encode("utf-8"))
         header = json.dumps({"kid": key.thumbprint()})

--- a/tests/integration/auth_adapter/test_api.py
+++ b/tests/integration/auth_adapter/test_api.py
@@ -135,7 +135,10 @@ def test_token_exchange(client):
     """Test that the external access token is exchanged against an internal token."""
 
     ext_payload = {"name": "Foo Bar", "email": "foo@bar", "sub": "foo", "iss": "bar"}
-    ext_sign_key = signing_keys.external_jwks.get_key("test")
+    ext_sign_keyset = signing_keys.external_jwks
+    assert ext_sign_keyset
+    ext_sign_key = ext_sign_keyset.get_key("test")
+    assert ext_sign_key
     auth = sign_and_encode_token(ext_payload, key=ext_sign_key)
     auth = f"Bearer {auth}"
     response = client.get("/some/path", headers={"Authorization": auth})
@@ -160,7 +163,10 @@ def test_token_exchange_with_x_token(client):
     """Test that the external access token can be passed in separate header."""
 
     ext_payload = {"name": "Foo Bar", "email": "foo@bar", "sub": "foo", "iss": "bar"}
-    ext_sign_key = signing_keys.external_jwks.get_key("test")
+    ext_sign_keyset = signing_keys.external_jwks
+    assert ext_sign_keyset
+    ext_sign_key = ext_sign_keyset.get_key("test")
+    assert ext_sign_key
     auth = sign_and_encode_token(ext_payload, key=ext_sign_key)
     auth = f"Bearer {auth}"
     response = client.get("/some/path", headers={"X-Authorization": auth})

--- a/tests/unit/auth_adapter/test_core.py
+++ b/tests/unit/auth_adapter/test_core.py
@@ -165,7 +165,10 @@ def test_signs_internal_token():
 def test_token_exchange():
     """Test that a valid external token is exchanged against an internal token."""
     ext_payload = {"name": "Foo Bar", "email": "foo@bar", "sub": "foo", "iss": "bar"}
-    ext_sign_key = signing_keys.external_jwks.get_key("test")
+    ext_sign_keyset = signing_keys.external_jwks
+    assert ext_sign_keyset
+    ext_sign_key = ext_sign_keyset.get_key("test")
+    assert ext_sign_key
     access_token = sign_and_encode_token(ext_payload, key=ext_sign_key)
     assert decode_and_verify_token(access_token) == ext_payload
     internal_token = exchange_token(access_token)


### PR DESCRIPTION
When the signing keys were missing or invalid, the auth adatper threw an error and did not start.

We now just log errors in this case, so that the website is still usable without authentication.