### PR TITLE
Fix an issue with the http auth exception handler

### DIFF
--- a/auth_service/auth_adapter/api/basic.py
+++ b/auth_service/auth_adapter/api/basic.py
@@ -79,7 +79,7 @@ def basic_auth(app: FastAPI, config: Config):
 
     @app.exception_handler(HTTPException)
     async def http_exception_handler(_request, exc):
-        if "WWW-Authenticate" in exc.headers:
+        if exc.headers and "WWW-Authenticate" in exc.headers:
             return PlainTextResponse(
                 f"{realm}: {exc.detail}",
                 status_code=exc.status_code,

--- a/scripts/update_openapi_docs.py
+++ b/scripts/update_openapi_docs.py
@@ -15,7 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Udates OpenAPI-based documentation"""
+"""Updates OpenAPI-based documentation"""
 
 import sys
 from pathlib import Path
@@ -31,13 +31,11 @@ OPENAPI_YAML = REPO_ROOT_DIR / "openapi.yaml"
 
 
 class ValidationError(RuntimeError):
-    """Raised when validation of openapi documentation failes."""
+    """Raised when validation of OpenAPI documentation fails."""
 
 
 def get_openapi_spec() -> str:
-    """Get an openapi spec in YAML format from the main FastAPI app as defined in the
-    _fastapi_app_location.py file.
-    """
+    """Get an openapi spec in YAML format from the main FastAPI app."""
 
     openapi_spec = get_app(create_auth_keys=True).openapi()
     return yaml.safe_dump(openapi_spec)


### PR DESCRIPTION
In the http exception handler for the basic authentication, the exc.headers attribute could be None, and that case was not handled, causing an error inside the exception handler.