### PR TITLE
Allow for a prefix when checking the path in the auth adapter

### DIFF
--- a/auth_service/auth_adapter/api/main.py
+++ b/auth_service/auth_adapter/api/main.py
@@ -48,6 +48,10 @@ configure_app(app, config=CONFIG)
 # the auth adapter needs to handle all HTTP methods
 HANDLE_METHODS = ["GET", "POST", "PUT", "DELETE", "OPTIONS", "HEAD", "PATCH"]
 
+API_EXT_PATH = CONFIG.api_ext_path.strip("/")
+if API_EXT_PATH:
+    API_EXT_PATH += "/"
+
 
 @app.api_route("/.well-known/{path:path}", methods=["GET"])
 async def ext_auth_well_known() -> dict:
@@ -92,9 +96,12 @@ async def ext_auth(  # pylint:disable=too-many-arguments
     return {}
 
 
-def path_needs_ext_info(path: str, method: str, prefix=CONFIG.api_ext_path) -> bool:
+def path_needs_ext_info(path: str, method: str) -> bool:
     """Check whether the given request path and method need external user info."""
-    path.removeprefix(prefix)
+    if API_EXT_PATH:
+        if not path.startswith(API_EXT_PATH):
+            return False
+        path = path[len(API_EXT_PATH) :]
     return (method == "POST" and path == "users") or (
         method == "GET" and path.startswith("users/") and "@" in path
     )

--- a/auth_service/auth_adapter/api/main.py
+++ b/auth_service/auth_adapter/api/main.py
@@ -48,9 +48,6 @@ configure_app(app, config=CONFIG)
 # the auth adapter needs to handle all HTTP methods
 HANDLE_METHODS = ["GET", "POST", "PUT", "DELETE", "OPTIONS", "HEAD", "PATCH"]
 
-# the path prefix of the auth API as mapped by the API gateway
-AUTH_PATH_PREFIX = "api/auth/"
-
 
 @app.api_route("/.well-known/{path:path}", methods=["GET"])
 async def ext_auth_well_known() -> dict:
@@ -95,9 +92,9 @@ async def ext_auth(  # pylint:disable=too-many-arguments
     return {}
 
 
-def path_needs_ext_info(path: str, method: str) -> bool:
+def path_needs_ext_info(path: str, method: str, prefix=CONFIG.api_ext_path) -> bool:
     """Check whether the given request path and method need external user info."""
-    path.removeprefix(AUTH_PATH_PREFIX)
+    path.removeprefix(prefix)
     return (method == "POST" and path == "users") or (
         method == "GET" and path.startswith("users/") and "@" in path
     )

--- a/auth_service/auth_adapter/api/main.py
+++ b/auth_service/auth_adapter/api/main.py
@@ -48,6 +48,8 @@ configure_app(app, config=CONFIG)
 # the auth adapter needs to handle all HTTP methods
 HANDLE_METHODS = ["GET", "POST", "PUT", "DELETE", "OPTIONS", "HEAD", "PATCH"]
 
+PATH_PREFIX = "api/auth/"
+
 
 @app.api_route("/.well-known/{path:path}", methods=["GET"])
 async def ext_auth_well_known() -> dict:
@@ -94,6 +96,7 @@ async def ext_auth(  # pylint:disable=too-many-arguments
 
 def path_needs_ext_info(path: str, method: str) -> bool:
     """Check whether the given request path and method need external user info."""
+    path.removeprefix(PATH_PREFIX)
     return (method == "POST" and path == "users") or (
         method == "GET" and path.startswith("users/") and "@" in path
     )

--- a/auth_service/auth_adapter/api/main.py
+++ b/auth_service/auth_adapter/api/main.py
@@ -48,7 +48,8 @@ configure_app(app, config=CONFIG)
 # the auth adapter needs to handle all HTTP methods
 HANDLE_METHODS = ["GET", "POST", "PUT", "DELETE", "OPTIONS", "HEAD", "PATCH"]
 
-PATH_PREFIX = "api/auth/"
+# the path prefix of the auth API as mapped by the API gateway
+AUTH_PATH_PREFIX = "api/auth/"
 
 
 @app.api_route("/.well-known/{path:path}", methods=["GET"])
@@ -96,7 +97,7 @@ async def ext_auth(  # pylint:disable=too-many-arguments
 
 def path_needs_ext_info(path: str, method: str) -> bool:
     """Check whether the given request path and method need external user info."""
-    path.removeprefix(PATH_PREFIX)
+    path.removeprefix(AUTH_PATH_PREFIX)
     return (method == "POST" and path == "users") or (
         method == "GET" and path.startswith("users/") and "@" in path
     )

--- a/auth_service/config.py
+++ b/auth_service/config.py
@@ -65,7 +65,7 @@ class Config(ApiConfigBase):
     run_auth_adapter: bool = False
 
     # extermal API path for the user management as seen by the auth adapter
-    api_ext_path: str = "api/auth/"
+    api_ext_path: str = "/api/auth"
 
     # internal public key for user management (key pair for auth adapter)
     auth_int_keys: Optional[str] = None

--- a/auth_service/config.py
+++ b/auth_service/config.py
@@ -64,6 +64,9 @@ class Config(ApiConfigBase):
 
     run_auth_adapter: bool = False
 
+    # extermal API path for the user management as seen by the auth adapter
+    api_ext_path: str = "api/auth/"
+
     # internal public key for user management (key pair for auth adapter)
     auth_int_keys: Optional[str] = None
     # external public key set for auth adapter (not used for user management)

--- a/config_schema.json
+++ b/config_schema.json
@@ -151,6 +151,14 @@
       ],
       "type": "boolean"
     },
+    "api_ext_path": {
+      "title": "Api Ext Path",
+      "default": "/api/auth",
+      "env_names": [
+        "auth_service_api_ext_path"
+      ],
+      "type": "string"
+    },
     "auth_int_keys": {
       "title": "Auth Int Keys",
       "env_names": [

--- a/example_config.yaml
+++ b/example_config.yaml
@@ -1,3 +1,4 @@
+api_ext_path: /api/auth
 api_root_path: /
 auth_ext_algs:
 - RS256


### PR DESCRIPTION
When checking the path in the auth adapter, ignore a possible API prefix (added by the API gateway mapping).

The prefix can be specified in the config as `api_ext_path`. Note that this is the effective path used in the API gateway mapping, different from the setting `api_root_path` which specifies a possible path where the API is mounted locally.