### PR TITLE
Remove status from creation model

### DIFF
--- a/auth_service/auth_adapter/api/main.py
+++ b/auth_service/auth_adapter/api/main.py
@@ -22,6 +22,7 @@ Note: If a path_prefix is used for the Emissary AuthService,
 then this must be also specified in the config setting api_root_path.
 """
 
+import logging  # Remove after testing
 from typing import Optional
 
 from fastapi import FastAPI, Header, HTTPException, Request, Response, status
@@ -41,6 +42,8 @@ from .basic import basic_auth
 from .headers import get_bearer_token
 
 configure_logging()
+
+log = logging.getLogger(__name__)  # remove after testing
 
 app = FastAPI(title=TITLE, description=DESCRIPTION, version=VERSION)
 configure_app(app, config=CONFIG)
@@ -98,6 +101,9 @@ async def ext_auth(  # pylint:disable=too-many-arguments
 
 def path_needs_ext_info(path: str, method: str) -> bool:
     """Check whether the given request path and method need external user info."""
+    log.info(
+        "path_needs_ext_info: %r %r %r", path, method, API_EXT_PATH
+    )  # Remove after testing
     if API_EXT_PATH:
         if not path.startswith(API_EXT_PATH):
             return False

--- a/auth_service/user_management/claims_repository/models/dto.py
+++ b/auth_service/user_management/claims_repository/models/dto.py
@@ -43,6 +43,7 @@ class BaseDto(BaseModel):
     """Base model preconfigured for use as Dto."""
 
     class Config:  # pylint: disable=missing-class-docstring
+        extra = "forbid"
         frozen = True
 
 

--- a/auth_service/user_management/user_registry/models/dto.py
+++ b/auth_service/user_management/user_registry/models/dto.py
@@ -47,6 +47,7 @@ class BaseDto(BaseModel):
     """Base model preconfigured for use as Dto."""
 
     class Config:  # pylint: disable=missing-class-docstring
+        extra = "forbid"
         frozen = True
 
 
@@ -71,9 +72,6 @@ class UserCreatableData(BaseDto):
         title="LS ID",
         description="Life Science ID",
         example="user@lifescience-ri.eu",
-    )
-    status: UserStatus = Field(
-        default=..., title="Status", description="Registration status of the user"
     )
     name: str = Field(
         default=...,
@@ -119,6 +117,10 @@ class UserAutomaticData(BaseModel):
 
 class UserData(UserCreatableData, UserAutomaticData):
     """User data model without the ID"""
+
+    status: UserStatus = Field(
+        default=..., title="Status", description="Registration status of the user"
+    )
 
 
 class User(UserData):

--- a/auth_service/user_management/user_registry/router.py
+++ b/auth_service/user_management/user_registry/router.py
@@ -35,6 +35,7 @@ from .models.dto import (
     UserCreatableData,
     UserData,
     UserModifiableData,
+    UserStatus,
 )
 from .utils import is_external_id, is_internal_id
 
@@ -84,7 +85,9 @@ async def post_user(
         pass
     else:
         raise HTTPException(status_code=409, detail="User was already registered.")
-    full_user_data = UserData(**user_data.dict(), registration_date=now_as_utc())
+    full_user_data = UserData(
+        **user_data.dict(), status=UserStatus.REGISTERED, registration_date=now_as_utc()
+    )
     try:
         user = await user_dao.insert(full_user_data)
     except Exception as error:

--- a/auth_service/user_management/user_registry/router.py
+++ b/auth_service/user_management/user_registry/router.py
@@ -125,6 +125,13 @@ async def get_user(
 ) -> User:
     """Get user data"""
     # Only data steward can request other user accounts
+    log.info(
+        "Getting user %s with token %s - external %s internal %s",
+        id_,
+        auth_token,
+        is_external_id(id_),
+        is_internal_id(id_),
+    )  # Remove after testing
     if not (
         auth_token.has_role("data_steward")
         or (is_external_id(id_) and id_ == auth_token.ls_id)

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -18,6 +18,7 @@ components:
       title: AuthorityLevel
       type: string
     Claim:
+      additionalProperties: false
       description: A claim about a user with a claim ID
       properties:
         asserted_by:
@@ -114,6 +115,7 @@ components:
       title: Claim
       type: object
     ClaimCreation:
+      additionalProperties: false
       description: A claim made about a user with a user ID
       properties:
         asserted_by:
@@ -184,6 +186,7 @@ components:
       title: ClaimCreation
       type: object
     ClaimMatch:
+      additionalProperties: false
       description: A pair of a claim name and a match value with type
       properties:
         claim:
@@ -200,6 +203,7 @@ components:
       title: ClaimMatch
       type: object
     ClaimUpdate:
+      additionalProperties: false
       description: A set of attributes that shall be updated in a claim.
       properties:
         revocation_date:
@@ -211,6 +215,7 @@ components:
       title: ClaimUpdate
       type: object
     Condition:
+      additionalProperties: false
       description: A single condition to check a type and a set of claims
       properties:
         matches:
@@ -226,6 +231,7 @@ components:
       title: Condition
       type: object
     Identity:
+      additionalProperties: false
       description: A user identity based on an iss/sub pair
       properties:
         iss:
@@ -261,6 +267,7 @@ components:
       title: MatchType
       type: string
     StatusChange:
+      additionalProperties: false
       description: Details of a status change
       properties:
         by:
@@ -281,6 +288,7 @@ components:
       title: StatusChange
       type: object
     User:
+      additionalProperties: false
       description: Complete user model with ID
       properties:
         email:
@@ -329,13 +337,14 @@ components:
       required:
       - registration_date
       - ls_id
-      - status
       - name
       - email
+      - status
       - id
       title: User
       type: object
     UserCreatableData:
+      additionalProperties: false
       description: User data
       properties:
         email:
@@ -361,11 +370,6 @@ components:
         research_topics:
           title: Research topic(s)
           type: string
-        status:
-          allOf:
-          - $ref: '#/components/schemas/UserStatus'
-          description: Registration status of the user
-          title: Status
         title:
           allOf:
           - $ref: '#/components/schemas/AcademicTitle'
@@ -373,12 +377,12 @@ components:
           title: Academic title
       required:
       - ls_id
-      - status
       - name
       - email
       title: UserCreatableData
       type: object
     UserModifiableData:
+      additionalProperties: false
       description: User data that can be modified
       properties:
         status:

--- a/tests/integration/user_management/user_registry/test_dao.py
+++ b/tests/integration/user_management/user_registry/test_dao.py
@@ -59,7 +59,7 @@ async def test_user_creation(
         title=AcademicTitle.DR,
         email="max@example.org",
         research_topics="genes",
-        registration_reasons="for testing",
+        registration_reason="for testing",
         registration_date=datetime_utc(2022, 9, 1, 12, 0),
         status_change=StatusChange(previous=None, by=None, context="test"),
     )

--- a/tests/unit/user_management/claims_repository/test_models.py
+++ b/tests/unit/user_management/claims_repository/test_models.py
@@ -38,9 +38,8 @@ datetime_utc = DateTimeUTC.construct
     ["foo@bar.org", "https://foo.org", [Identity(iss="https://bar.org", sub="baz")]],
 )
 def test_good_visa_values(value):
-    """Test creating an invalid visa value"""
+    """Test creating a valid visa value"""
     ClaimCreation(
-        user_id="foo-bar",
         visa_type=VisaType.CONTROLLED_ACCESS_GRANTS,
         visa_value=value,
         assertion_date=datetime_utc(2022, 9, 1, 12, 0),
@@ -66,7 +65,6 @@ def test_bad_visa_values(value):
     """Test creating an invalid visa value"""
     with raises(ValueError):
         ClaimCreation(
-            user_id="foo-bar",
             visa_type=VisaType.CONTROLLED_ACCESS_GRANTS,
             visa_value=value,
             assertion_date=datetime_utc(2022, 9, 1, 12, 0),
@@ -79,7 +77,6 @@ def test_bad_visa_values(value):
 def test_conditions():
     """Test creating a complex condition"""
     ClaimCreation(
-        user_id="foo-bar",
         visa_type=VisaType.CONTROLLED_ACCESS_GRANTS,
         visa_value="baz@foo-bar.org",
         assertion_date=datetime_utc(2022, 9, 1, 12, 0),
@@ -88,7 +85,7 @@ def test_conditions():
         source="https://foo-bar.org",
         sub_source="https://baz.foo-bar.org",
         asserted_by=AuthorityLevel.DAC,
-        condition=[
+        conditions=[
             [
                 Condition(
                     type=VisaType.AFFILIATION_AND_ROLE,
@@ -165,7 +162,6 @@ def test_conditions():
 def test_validator_period(valid_from, valid_until):
     """Test the validator for valid_from and valid_until"""
     ClaimCreation(
-        user_id="foo",
         visa_type=VisaType.RESEARCHER_STATUS,
         visa_value="foo@bar.org",
         assertion_date=datetime_utc(2022, 9, 1, 12, 0),


### PR DESCRIPTION
When registering a new user, the initial status should be set automatically by the backend, and the status field should not be part of the creation field. This PR also disallows passing fields that are not specified in the schema.

This PR also adds temporary logging for debugging in the staging environment.