### PR TITLE
Also pass LS ID in internal token when user exists

### DIFF
--- a/auth_service/__init__.py
+++ b/auth_service/__init__.py
@@ -19,4 +19,4 @@ The GHGA auth service contains all services needed for the management,
 authentication and authorization of users.
 """
 
-__version__ = "0.2.1"
+__version__ = "0.2.2"

--- a/auth_service/auth_adapter/api/main.py
+++ b/auth_service/auth_adapter/api/main.py
@@ -22,7 +22,6 @@ Note: If a path_prefix is used for the Emissary AuthService,
 then this must be also specified in the config setting api_root_path.
 """
 
-import logging  # Remove after testing
 from typing import Optional
 
 from fastapi import FastAPI, Header, HTTPException, Request, Response, status
@@ -42,8 +41,6 @@ from .basic import basic_auth
 from .headers import get_bearer_token
 
 configure_logging()
-
-log = logging.getLogger(__name__)  # remove after testing
 
 app = FastAPI(title=TITLE, description=DESCRIPTION, version=VERSION)
 configure_app(app, config=CONFIG)
@@ -101,9 +98,6 @@ async def ext_auth(  # pylint:disable=too-many-arguments
 
 def path_needs_ext_info(path: str, method: str) -> bool:
     """Check whether the given request path and method need external user info."""
-    log.info(
-        "path_needs_ext_info: %r %r %r", path, method, API_EXT_PATH
-    )  # Remove after testing
     if API_EXT_PATH:
         if not path.startswith(API_EXT_PATH):
             return False

--- a/auth_service/auth_adapter/core/auth.py
+++ b/auth_service/auth_adapter/core/auth.py
@@ -189,7 +189,6 @@ async def exchange_token(
         # user is not yet registered
         if not pass_sub:
             return None
-        internal_claims[jwt_config.copy_sub_as] = sub
     else:
         # user already exists in the registry
         try:
@@ -203,6 +202,8 @@ async def exchange_token(
             user.id, user_dao=user_dao, claim_dao=claim_dao
         ):
             internal_claims.update(role="data_steward")
+    if pass_sub:
+        internal_claims[jwt_config.copy_sub_as] = sub
     return sign_and_encode_token(internal_claims)
 
 

--- a/auth_service/user_management/user_registry/router.py
+++ b/auth_service/user_management/user_registry/router.py
@@ -125,13 +125,6 @@ async def get_user(
 ) -> User:
     """Get user data"""
     # Only data steward can request other user accounts
-    log.info(
-        "Getting user %s with token %s - external %s internal %s",
-        id_,
-        auth_token,
-        is_external_id(id_),
-        is_internal_id(id_),
-    )  # Remove after testing
     if not (
         auth_token.has_role("data_steward")
         or (is_external_id(id_) and id_ == auth_token.ls_id)

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -429,7 +429,7 @@ info:
   license:
     name: Apache 2.0
   title: User Management API
-  version: 0.2.1
+  version: 0.2.2
 openapi: 3.0.2
 paths:
   /health:

--- a/tests/unit/auth_adapter/test_token_exchange.py
+++ b/tests/unit/auth_adapter/test_token_exchange.py
@@ -92,8 +92,8 @@ async def test_exchanges_access_token_for_a_known_user():
 
 
 @mark.asyncio
-async def test_does_not_pass_sub_for_a_known_user():
-    """Test that the sub claim is never passed for an already known user."""
+async def test_also_passes_sub_for_a_known_user():
+    """Test that the sub claim is also passed for an already known user."""
     access_token = create_access_token()
     user_dao, claim_dao = DummyUserDao(), DummyClaimDao()
     internal_token = await auth.exchange_token(
@@ -102,7 +102,8 @@ async def test_does_not_pass_sub_for_a_known_user():
     assert internal_token is not None
     claims = get_claims_from_token(internal_token)
     assert isinstance(claims, dict)
-    assert "ls_id" not in claims
+    assert claims["id"] == "john@ghga.de"
+    assert claims["ls_id"] == "john@aai.org"
 
 
 @mark.asyncio


### PR DESCRIPTION
To pass the authorization check, the LS ID must be passed in the internal token even when the user exists.

However, it is still only passed when registering users and requesting users. All other endpoints do not need the LS ID and therefore should not get it (data minimization principle).