### PR TITLE
Support fixing user invalidation due to name or email change (GDEV-1570)

### DIFF
--- a/auth_service/__init__.py
+++ b/auth_service/__init__.py
@@ -19,4 +19,4 @@ The GHGA auth service contains all services needed for the management,
 authentication and authorization of users.
 """
 
-__version__ = "0.2.2"
+__version__ = "0.2.3"

--- a/auth_service/auth_adapter/api/main.py
+++ b/auth_service/auth_adapter/api/main.py
@@ -22,7 +22,6 @@ Note: If a path_prefix is used for the Emissary AuthService,
 then this must be also specified in the config setting api_root_path.
 """
 
-import logging  # Remove after testing
 from typing import Optional
 
 from fastapi import FastAPI, Header, HTTPException, Request, Response, status
@@ -42,8 +41,6 @@ from .basic import basic_auth
 from .headers import get_bearer_token
 
 configure_logging()
-
-log = logging.getLogger(__name__)  # remove after testing
 
 app = FastAPI(title=TITLE, description=DESCRIPTION, version=VERSION)
 configure_app(app, config=CONFIG)
@@ -101,9 +98,6 @@ async def ext_auth(  # pylint:disable=too-many-arguments
 
 def path_needs_ext_info(path: str, method: str) -> bool:
     """Check whether the given request path and method need external user info."""
-    log.info(
-        "path_needs_ext_info: %r %r %r", path, method, API_EXT_PATH
-    )  # Remove after testing
     if API_EXT_PATH:
         if not path.startswith(API_EXT_PATH):
             return False

--- a/auth_service/user_management/auth.py
+++ b/auth_service/user_management/auth.py
@@ -108,7 +108,7 @@ class AuthToken(BaseModel):
     def has_role(self, role: str) -> bool:
         """Check whether the user has the given role, no matter w"""
         return (
-            self.status == UserStatus.ACTIVATED
+            self.status == UserStatus.ACTIVE
             and self.role is not None
             and self.role.split("@", 1)[0] == role
         )
@@ -148,15 +148,15 @@ class FetchAuthToken(SecurityBase):
 class RequireAuthToken(SecurityBase):
     """Fetches a required internal authorization token."""
 
-    def __init__(self, activated: bool = True, role: Optional[str] = None):
+    def __init__(self, active: bool = True, role: Optional[str] = None):
         """Initialize authorization token fetcher.
 
-        By default, the user must be activated. A role can also be required.
+        By default, the user must be active. A role can also be required.
         """
         self.http_bearer = HTTPBearer(auto_error=True)
         self.model = self.http_bearer.model
         self.scheme_name = self.http_bearer.scheme_name
-        self.activated = activated
+        self.active = active
         self.role = role
 
     async def __call__(self, request: Request) -> AuthToken:
@@ -167,8 +167,8 @@ class RequireAuthToken(SecurityBase):
             raise forbidden_error
         try:
             token = AuthToken(**decode_and_validate_token(bearer_token))
-            if self.activated and token.status is not UserStatus.ACTIVATED:
-                raise ValueError("User is not activated")
+            if self.active and token.status is not UserStatus.ACTIVE:
+                raise ValueError("User is not active")
             role = self.role
             if role:
                 user_role = token.role

--- a/auth_service/user_management/user_registry/models/dto.py
+++ b/auth_service/user_management/user_registry/models/dto.py
@@ -30,10 +30,9 @@ __all__ = ["User", "UserData", "UserStatus", "StatusChange"]
 class UserStatus(str, Enum):
     """User status enum"""
 
-    REGISTERED = "registered"
-    ACTIVATED = "activated"
-    INACTIVATED = "inactivated"
-    DELETED = "deleted"
+    ACTIVE = "active"
+    INACTIVE = "inactive"
+    INVALID = "invalid"
 
 
 class AcademicTitle(str, Enum):
@@ -64,15 +63,9 @@ class StatusChange(BaseDto):
     change_date: DateTimeUTC = Field(default=None, title="Date of last change")
 
 
-class UserCreatableData(BaseDto):
-    """User data"""
+class UserBasicData(BaseDto):
+    """Basic data of a user"""
 
-    ls_id: EmailStr = Field(
-        default=...,
-        title="LS ID",
-        description="Life Science ID",
-        example="user@lifescience-ri.eu",
-    )
     name: str = Field(
         default=...,
         title="Name",
@@ -87,6 +80,17 @@ class UserCreatableData(BaseDto):
         title="E-Mail",
         description="Preferred e-mail address of the user",
         example="user@home.org",
+    )
+
+
+class UserRegisteredData(UserBasicData):
+    """Basic data of a registered user"""
+
+    ls_id: EmailStr = Field(
+        default=...,
+        title="LS ID",
+        description="Life Science ID",
+        example="user@lifescience-ri.eu",
     )
 
 
@@ -120,7 +124,7 @@ class UserAutomaticData(BaseModel):
     )
 
 
-class UserData(UserCreatableData, UserAutomaticData):
+class UserData(UserRegisteredData, UserAutomaticData):
     """User data model without the ID"""
 
     status: UserStatus = Field(

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -345,16 +345,57 @@ components:
           title: Academic title
       required:
       - registration_date
-      - ls_id
       - name
       - email
+      - ls_id
       - status
       - id
       title: User
       type: object
-    UserCreatableData:
+    UserBasicData:
       additionalProperties: false
-      description: User data
+      description: Basic data of a user
+      properties:
+        email:
+          description: Preferred e-mail address of the user
+          example: user@home.org
+          format: email
+          title: E-Mail
+          type: string
+        name:
+          description: Full name of the user
+          example: Rosalind Franklin
+          title: Name
+          type: string
+        title:
+          allOf:
+          - $ref: '#/components/schemas/AcademicTitle'
+          description: Academic title of the user
+          title: Academic title
+      required:
+      - name
+      - email
+      title: UserBasicData
+      type: object
+    UserModifiableData:
+      additionalProperties: false
+      description: User data that can be modified
+      properties:
+        status:
+          allOf:
+          - $ref: '#/components/schemas/UserStatus'
+          description: Registration status of the user
+          title: Status
+        title:
+          allOf:
+          - $ref: '#/components/schemas/AcademicTitle'
+          description: Academic title of the user
+          title: Academic title
+      title: UserModifiableData
+      type: object
+    UserRegisteredData:
+      additionalProperties: false
+      description: Basic data of a registered user
       properties:
         email:
           description: Preferred e-mail address of the user
@@ -379,34 +420,17 @@ components:
           description: Academic title of the user
           title: Academic title
       required:
-      - ls_id
       - name
       - email
-      title: UserCreatableData
-      type: object
-    UserModifiableData:
-      additionalProperties: false
-      description: User data that can be modified
-      properties:
-        status:
-          allOf:
-          - $ref: '#/components/schemas/UserStatus'
-          description: Registration status of the user
-          title: Status
-        title:
-          allOf:
-          - $ref: '#/components/schemas/AcademicTitle'
-          description: Academic title of the user
-          title: Academic title
-      title: UserModifiableData
+      - ls_id
+      title: UserRegisteredData
       type: object
     UserStatus:
       description: User status enum
       enum:
-      - registered
-      - activated
-      - inactivated
-      - deleted
+      - active
+      - inactive
+      - invalid
       title: UserStatus
       type: string
     VisaType:
@@ -457,7 +481,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/UserCreatableData'
+              $ref: '#/components/schemas/UserRegisteredData'
         required: true
       responses:
         '201':
@@ -466,8 +490,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/User'
           description: User was successfully registered.
-        '400':
-          description: User cannot be registered.
         '403':
           description: Not authorized to register user.
         '409':
@@ -575,6 +597,40 @@ paths:
       security:
       - HTTPBearer: []
       summary: Modify user data
+      tags:
+      - users
+    put:
+      description: Endpoint used to update a registered user when their name or email
+        used by LS Login have changed. May only be performed by the users themselves.
+        Data delivered by the OIDC provider may not be altered.
+      operationId: put_user
+      parameters:
+      - in: path
+        name: id
+        required: true
+        schema:
+          title: Internal ID
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UserBasicData'
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User'
+          description: User was successfully updated.
+        '403':
+          description: Not authorized to update user.
+        '422':
+          description: Validation error in submitted user data.
+      security:
+      - HTTPBearer: []
+      summary: Update a user
       tags:
       - users
   /users/{user_id}/claims:

--- a/tests/fixtures/utils.py
+++ b/tests/fixtures/utils.py
@@ -130,7 +130,7 @@ def create_internal_token(
     assert kty in ("EC", "RSA")
     header = {"alg": "ES256" if kty == "EC" else "RS256", "typ": "JWT"}
     claims: dict[str, Union[None, int, str]] = dict(
-        name="John Doe", email="john@home.org", status="activated"
+        name="John Doe", email="john@home.org", status="active"
     )
     iat = int(now_as_utc().timestamp())
     if expired:
@@ -193,6 +193,7 @@ class DummyUserDao:
         name="John Doe",
         email="john@home.org",
         ls_id="john@aai.org",
+        status=UserStatus.ACTIVE,
     ):
         """Initialize the dummy UserDao"""
         self.user = User(
@@ -200,7 +201,7 @@ class DummyUserDao:
             name=name,
             email=email,
             ls_id=ls_id,
-            status=UserStatus.ACTIVATED,
+            status=status,
             status_change=None,
             registration_date=datetime_utc(2020, 1, 1),
         )

--- a/tests/integration/user_management/conftest.py
+++ b/tests/integration/user_management/conftest.py
@@ -29,7 +29,7 @@ def config_for_user_management() -> None:
 
 @fixture(autouse=True, scope="package")
 def user_headers() -> dict[str, str]:
-    """Get headers with authorization for a user with data steward role."""
+    """Get headers with authorization for an unregistered user."""
     return get_headers_for(
         ls_id="max@ls.org", name="Max Headroom", email="max@example.org"
     )

--- a/tests/integration/user_management/user_registry/test_api.py
+++ b/tests/integration/user_management/user_registry/test_api.py
@@ -70,7 +70,7 @@ def test_post_user(client_with_db, user_headers):
     id_ = user.pop("id", None)
     assert is_internal_id(id_)
 
-    assert user.pop("status") == "activated"
+    assert user.pop("status") == "active"
     assert user.pop("status_change") is None
     date_diff = now_as_utc() - datetime.fromisoformat(user.pop("registration_date"))
     assert 0 <= date_diff.total_seconds() <= 10
@@ -99,7 +99,7 @@ def test_post_user_with_minimal_data(client_with_db, user_headers):
     id_ = user.pop("id", None)
     assert is_internal_id(id_)
 
-    assert user.pop("status") == "activated"
+    assert user.pop("status") == "active"
     assert user.pop("status_change") is None
     date_diff = now_as_utc() - datetime.fromisoformat(user.pop("registration_date"))
     assert 0 <= date_diff.total_seconds() <= 10
@@ -119,7 +119,7 @@ def test_post_user_with_minimal_data(client_with_db, user_headers):
 def test_post_user_with_status(client_with_db, user_headers):
     """Test that status field is rejected when registering a user."""
 
-    user_data = {**MIN_USER_DATA, "status": "activated"}
+    user_data = {**MIN_USER_DATA, "status": "active"}
     response = client_with_db.post("/users", json=user_data, headers=user_headers)
 
     assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
@@ -131,7 +131,7 @@ def test_post_user_with_different_name(client, user_headers):
     user_data = {**MAX_USER_DATA, "name": "Max Liebermann"}
     response = client.post("/users", json=user_data, headers=user_headers)
 
-    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
     error = response.json()
     assert error["detail"] == "User cannot be registered."
 
@@ -142,7 +142,7 @@ def test_post_user_with_different_email(client, user_headers):
     user_data = {**MAX_USER_DATA, "email": "max@fake.org"}
     response = client.post("/users", json=user_data, headers=user_headers)
 
-    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
     error = response.json()
     assert error["detail"] == "User cannot be registered."
 
@@ -169,10 +169,122 @@ def test_post_user_with_different_ls_id(client, user_headers):
     assert error["detail"] == "Not authorized to register user."
 
 
-def test_post_user_unauthenticated(client_with_db, user_headers):
+def test_post_user_unauthenticated(client_with_db):
     """Test that registering a user without authentication does not work."""
 
     response = client_with_db.post("/users", json=MAX_USER_DATA)
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+    error = response.json()
+    assert error["detail"] == "Not authenticated"
+
+
+def test_put_user(client_with_db, user_headers):
+    """Test that updating a user works."""
+
+    old_data = MAX_USER_DATA
+    response = client_with_db.post("/users", json=old_data, headers=user_headers)
+    assert response.status_code == status.HTTP_201_CREATED
+    id_ = response.json()["id"]
+    assert is_internal_id(id_)
+
+    new_data = {"name": "Max Headhall", "email": "head@example.org", "title": "Prof."}
+    for key, value in new_data.items():
+        assert value != old_data[key]
+
+    headers = get_headers_for(id=id_, name=old_data["name"], email=old_data["email"])
+
+    response = client_with_db.put(f"/users/{id_}", json=new_data, headers=headers)
+    assert response.status_code == status.HTTP_200_OK
+
+    user = response.json()
+    put_user = user.copy()
+
+    assert user.pop("id") == id_
+    assert user.pop("ls_id") == old_data["ls_id"]
+    assert user.pop("status") == "active"
+    assert user.pop("status_change") is None
+    date_diff = now_as_utc() - datetime.fromisoformat(user.pop("registration_date"))
+    assert 0 <= date_diff.total_seconds() <= 10
+    assert user.pop("active_submissions") == []
+    assert user.pop("active_access_requests") == []
+
+    assert user == new_data
+
+    response = client_with_db.get(f"/users/{id_}", headers=headers)
+    assert response.status_code == status.HTTP_200_OK
+    user = response.json()
+
+    assert user == put_user
+
+
+def test_put_nonexisting_user(client_with_db):
+    """Test updating a non-existing user."""
+
+    user_data = MAX_USER_DATA.copy()
+    del user_data["ls_id"]
+
+    id_ = "nonexisting-user-id"
+    headers = get_headers_for(id=id_, name=user_data["name"], email=user_data["email"])
+
+    response = client_with_db.put(f"/users/{id_}", json=user_data, headers=headers)
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+def test_put_user_with_too_much_data(client_with_db):
+    """Test that updating a user with too much data does not work."""
+
+    user_data = MAX_USER_DATA
+    id_ = "nonexisting-user-id"
+    headers = get_headers_for(id=id_, name=user_data["name"], email=user_data["email"])
+
+    response = client_with_db.put(f"/users/{id_}", json=user_data, headers=headers)
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    error = response.json()
+    assert error["detail"][0]["msg"] == "extra fields not permitted"
+
+
+def test_put_user_with_invalid_data(client_with_db):
+    """Test that updating a user with invalid email does not work."""
+
+    user_data = MAX_USER_DATA.copy()
+    del user_data["ls_id"]
+    id_ = "nonexisting-user-id"
+    headers = get_headers_for(id=id_, name=user_data["name"], email=user_data["email"])
+
+    user_data["email"] = "invalid"
+
+    response = client_with_db.put(f"/users/{id_}", json=user_data, headers=headers)
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    error = response.json()
+    assert error["detail"][0]["msg"] == "value is not a valid email address"
+
+
+def test_put_inactive_user(client_with_db, user_headers):
+    """Test updating an inactive user."""
+
+    user_data = MAX_USER_DATA
+    response = client_with_db.post("/users", json=user_data, headers=user_headers)
+    assert response.status_code == status.HTTP_201_CREATED
+    id_ = response.json()["id"]
+    assert is_internal_id(id_)
+
+    user_data = user_data.copy()
+    del user_data["ls_id"]
+    headers = get_headers_for(
+        id=id_,
+        name=user_data["name"],
+        email=user_data["email"],
+        status="inactive",
+    )
+    response = client_with_db.put(f"/users/{id_}", json=user_data, headers=headers)
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+def test_put_user_unauthenticated(client_with_db, user_headers):
+    """Test that updating a user without authentication does not work."""
+
+    response = client_with_db.put("/users/nonexisting-user-id", json=MAX_USER_DATA)
 
     assert response.status_code == status.HTTP_403_FORBIDDEN
     error = response.json()
@@ -305,10 +417,10 @@ def test_patch_user_as_data_steward(client_with_db, user_headers, steward_header
     assert response.status_code == status.HTTP_201_CREATED
     id_ = expected_user["id"]
 
-    assert expected_user["status"] == "activated"
+    assert expected_user["status"] == "active"
     assert expected_user.pop("status_change") is None
 
-    update_data = {"status": "inactivated", "title": "Prof."}
+    update_data = {"status": "inactive", "title": "Prof."}
     assert expected_user["status"] != update_data["status"]
     assert expected_user["title"] != update_data["title"]
     expected_user.update(update_data)
@@ -327,7 +439,7 @@ def test_patch_user_as_data_steward(client_with_db, user_headers, steward_header
 
     # can get status change as data steward
     status_change = user.pop("status_change")
-    assert status_change["previous"] == "activated"
+    assert status_change["previous"] == "active"
     assert status_change["by"] == "steve-internal"
     assert status_change["context"] == "manual change"
     date_diff = now_as_utc() - datetime.fromisoformat(status_change["change_date"])
@@ -358,10 +470,10 @@ def test_patch_user_partially(client_with_db, user_headers, steward_headers):
     expected_user = response.json()
     id_ = expected_user["id"]
 
-    assert expected_user["status"] == "activated"
+    assert expected_user["status"] == "active"
     assert expected_user.pop("status_change") is None
 
-    update_data = {"status": "inactivated"}
+    update_data = {"status": "inactive"}
     assert expected_user["status"] != update_data["status"]
     expected_user.update(update_data)
 
@@ -377,7 +489,7 @@ def test_patch_user_partially(client_with_db, user_headers, steward_headers):
     user = response.json()
 
     status_change = user.pop("status_change")
-    assert status_change["previous"] == "activated"
+    assert status_change["previous"] == "active"
     assert status_change["by"] == "steve-internal"
     assert status_change["context"] == "manual change"
     date_diff = now_as_utc() - datetime.fromisoformat(status_change["change_date"])
@@ -415,7 +527,7 @@ def test_patch_user_as_same_user(client_with_db, user_headers, steward_headers):
     id_ = expected_user["id"]
 
     # check that users cannot change their own status
-    update_data = {"status": "inactivated"}
+    update_data = {"status": "inactive"}
     assert expected_user["status"] != update_data["status"]
     headers = get_headers_for(id=id_, name="Max Headroom", email="max@example.org")
     response = client_with_db.patch(f"/users/{id_}", json=update_data, headers=headers)

--- a/tests/integration/user_management/user_registry/test_dao.py
+++ b/tests/integration/user_management/user_registry/test_dao.py
@@ -54,7 +54,7 @@ async def test_user_creation(
 
     user_data = UserData(
         ls_id="max@ls.org",
-        status=UserStatus.ACTIVATED,
+        status=UserStatus.ACTIVE,
         name="Max Headroom",
         title=AcademicTitle.DR,
         email="max@example.org",

--- a/tests/unit/auth_adapter/test_token_exchange.py
+++ b/tests/unit/auth_adapter/test_token_exchange.py
@@ -83,11 +83,11 @@ async def test_exchanges_access_token_for_a_known_user():
     assert claims["name"] == "John Doe"
     assert claims["email"] == "john@home.org"
     assert claims["id"] == "john@ghga.de"
-    assert claims["status"] == "activated"
+    assert claims["status"] == "active"
     assert isinstance(claims["iat"], int)
     assert isinstance(claims["exp"], int)
     assert claims["iat"] <= int(now_as_utc().timestamp()) < claims["exp"]
-    assert user_dao.user.status is UserStatus.ACTIVATED
+    assert user_dao.user.status is UserStatus.ACTIVE
     assert user_dao.user.status_change is None
 
 
@@ -120,16 +120,13 @@ async def test_exchanges_access_token_when_name_was_changed():
     assert claims["name"] == "John Doe"
     assert claims["email"] == "john@home.org"
     assert claims["id"] == "john@ghga.de"
-    assert claims["status"] == "inactivated"
+    assert claims["status"] == "invalid"
     assert isinstance(claims["iat"], int)
     assert isinstance(claims["exp"], int)
     assert claims["iat"] <= int(now_as_utc().timestamp()) < claims["exp"]
-    status_change = user_dao.user.status_change
-    assert status_change is not None
-    assert status_change.previous is UserStatus.ACTIVATED
-    assert status_change.by is None
-    assert status_change.context == "name changed"
-    assert 0 <= (now_as_utc() - status_change.change_date).total_seconds() < 5
+    user = user_dao.user
+    assert user.status is UserStatus.ACTIVE
+    assert user.status_change is None
 
 
 @mark.asyncio
@@ -146,16 +143,13 @@ async def test_exchanges_access_token_when_email_was_changed():
     assert claims["name"] == "John Doe"
     assert claims["email"] == "john@home.org"
     assert claims["id"] == "john@ghga.de"
-    assert claims["status"] == "inactivated"
+    assert claims["status"] == "invalid"
     assert isinstance(claims["iat"], int)
     assert isinstance(claims["exp"], int)
     assert claims["iat"] <= int(now_as_utc().timestamp()) < claims["exp"]
-    status_change = user_dao.user.status_change
-    assert status_change is not None
-    assert status_change.previous is UserStatus.ACTIVATED
-    assert status_change.by is None
-    assert status_change.context == "email changed"
-    assert 0 <= (now_as_utc() - status_change.change_date).total_seconds() < 5
+    user = user_dao.user
+    assert user.status is UserStatus.ACTIVE
+    assert user.status_change is None
 
 
 @mark.asyncio
@@ -172,6 +166,26 @@ async def test_adds_role_for_a_known_data_steward():
     expected_claims = {"email", "name", "id", "status", "exp", "iat", "role"}
     assert set(claims) == expected_claims
     assert claims["id"] == "james@ghga.de"
-    assert claims["status"] == "activated"
+    assert claims["status"] == "active"
 
     assert claims["role"] == "data_steward"
+
+
+@mark.asyncio
+async def test_does_not_add_role_for_a_known_inactive_data_steward():
+    """Test that the token does not contain the role for an inactive data steward."""
+    access_token = create_access_token()
+    user_dao, claim_dao = (
+        DummyUserDao(id_="james@ghga.de", status=UserStatus.INACTIVE),
+        DummyClaimDao(),
+    )
+    internal_token = await auth.exchange_token(
+        access_token, user_dao=user_dao, claim_dao=claim_dao
+    )
+    assert internal_token is not None
+    claims = get_claims_from_token(internal_token)
+    assert isinstance(claims, dict)
+    expected_claims = {"email", "name", "id", "status", "exp", "iat"}
+    assert set(claims) == expected_claims
+    assert claims["id"] == "james@ghga.de"
+    assert claims["status"] == "inactive"

--- a/tests/unit/user_management/test_auth.py
+++ b/tests/unit/user_management/test_auth.py
@@ -47,7 +47,7 @@ def test_decodes_and_validates_an_internal_token():
     }
     assert claims["name"] == "John Doe"
     assert claims["email"] == "john@home.org"
-    assert claims["status"] == "activated"
+    assert claims["status"] == "active"
     assert isinstance(claims["iat"], int)
     assert isinstance(claims["exp"], int)
     assert claims["iat"] <= int(now_as_utc().timestamp()) < claims["exp"]
@@ -178,7 +178,7 @@ async def test_fetches_internal_token_from_an_authorization_header(fetcher: type
     assert isinstance(token.exp, datetime)
     assert token.exp.tzinfo is UTC
     assert token.iat <= now_as_utc() < token.exp
-    assert token.status == UserStatus.ACTIVATED
+    assert token.status == UserStatus.ACTIVE
 
 
 @mark.parametrize("fetcher", [auth.FetchAuthToken, auth.RequireAuthToken])
@@ -202,7 +202,7 @@ async def test_fetches_internal_token_with_additional_attributes(fetcher: type):
     assert token.name == "John Doe"
     assert token.id == "some-internal-id"
     assert token.ls_id == "some-id@aai.org"
-    assert token.status == UserStatus.ACTIVATED
+    assert token.status == UserStatus.ACTIVE
     assert token.role == "admin@some.hub"
 
 
@@ -277,10 +277,10 @@ async def test_does_not_accept_missing_token_when_required():
 
 
 @mark.asyncio
-async def test_accepts_an_inactivated_user_when_optional():
-    """Test that no error is raised when an optional user is inactivated."""
+async def test_accepts_an_inactive_user_when_optional():
+    """Test that no error is raised when an optional user is inactive."""
 
-    request = request_with_authorization(create_internal_token(status="inactivated"))
+    request = request_with_authorization(create_internal_token(status="inactive"))
 
     fetch_auth_token = auth.FetchAuthToken()
     token = await fetch_auth_token(request=request)
@@ -288,14 +288,14 @@ async def test_accepts_an_inactivated_user_when_optional():
     assert isinstance(token, auth.AuthToken)
 
     assert token.name == "John Doe"
-    assert token.status == UserStatus.INACTIVATED
+    assert token.status == UserStatus.INACTIVE
 
 
 @mark.asyncio
-async def test_does_not_accept_inactivated_user_when_required_by_default():
-    """Test that an error is raised when the user is inactivated and required."""
+async def test_does_not_accept_inactive_user_when_required_by_default():
+    """Test that an error is raised when the user is inactive and required."""
 
-    request = request_with_authorization(create_internal_token(status="inactivated"))
+    request = request_with_authorization(create_internal_token(status="inactive"))
     fetch_auth_token = auth.RequireAuthToken()
     with raises(HTTPException) as exc_info:
         assert await fetch_auth_token(request=request) is None
@@ -305,18 +305,18 @@ async def test_does_not_accept_inactivated_user_when_required_by_default():
 
 
 @mark.asyncio
-async def test_can_fetch_an_inactivated_but_required_user():
-    """Test that no error is raised when a required user may be inactivated."""
+async def test_can_fetch_an_inactive_but_required_user():
+    """Test that no error is raised when a required user may be inactive."""
 
-    request = request_with_authorization(create_internal_token(status="inactivated"))
+    request = request_with_authorization(create_internal_token(status="inactive"))
 
-    fetch_auth_token = auth.RequireAuthToken(activated=False)
+    fetch_auth_token = auth.RequireAuthToken(active=False)
     token = await fetch_auth_token(request=request)
     assert token
     assert isinstance(token, auth.AuthToken)
 
     assert token.name == "John Doe"
-    assert token.status == UserStatus.INACTIVATED
+    assert token.status == UserStatus.INACTIVE
 
 
 @mark.parametrize("required_role", [None, "", "admin", "admin@some_hub", "boss"])


### PR DESCRIPTION
- Simplify user status enum
- If there is a mismatch in user data, do not auto update the status to inactive, instead use the transient status "invalid" in the token
- Allow user to fix the data mismatch (confirm the data provided by LS Login) using a new endpoint with PUT method