### PR TITLE
Support userinfo endpoint

### DIFF
--- a/.devcontainer/dev_install
+++ b/.devcontainer/dev_install
@@ -7,7 +7,7 @@ cd /workspace
 python -m pip install --upgrade pip
 
 # install with all extras in editable mode
-pip install -r requirements.txt
+pip install -e .[all]
 
 # install or upgrade dependencies for development and testing
 pip install --upgrade -r requirements-dev.txt

--- a/auth_service/auth_adapter/api/main.py
+++ b/auth_service/auth_adapter/api/main.py
@@ -36,7 +36,7 @@ from auth_service.user_management.user_registry.deps import (
 )
 
 from .. import DESCRIPTION, TITLE, VERSION
-from ..core.auth import TokenValidationError, exchange_token
+from ..core.auth import TokenValidationError, UserInfoError, exchange_token
 from .basic import basic_auth
 from .headers import get_bearer_token
 
@@ -87,6 +87,10 @@ async def ext_auth(  # pylint:disable=too-many-arguments
         except TokenValidationError as exc:
             raise HTTPException(
                 status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid access token"
+            ) from exc
+        except UserInfoError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED, detail="Error in user info"
             ) from exc
     else:
         internal_token = ""  # nosec

--- a/auth_service/auth_adapter/core/auth.py
+++ b/auth_service/auth_adapter/core/auth.py
@@ -18,8 +18,11 @@
 
 import json
 import logging
+from functools import cached_property, lru_cache
 from typing import Any, Optional
 
+import httpx
+from fastapi import status
 from hexkit.protocols.dao import NoHitsFoundError
 from jwcrypto import jwk, jwt
 from jwcrypto.common import JWException
@@ -34,13 +37,15 @@ __all__ = ["exchange_token", "jwt_config"]
 
 log = logging.getLogger(__name__)
 
+TIMEOUT = 30  # network timeout in seconds
+
 
 class AuthAdapterError(Exception):
     """Auth adapter related error."""
 
 
 class ConfigurationMissingKey(AuthAdapterError):
-    """Missing key in configuration"""
+    """Missing key in configuration."""
 
 
 class TokenSigningError(AuthAdapterError):
@@ -55,32 +60,119 @@ class UserDataMismatchError(AuthAdapterError):
     """Raised when user claims do not match the registered user data."""
 
 
+class UserInfoError(AuthAdapterError):
+    """Error when retrieving data from the userinfo endpoint."""
+
+
+class ConfigurationDiscoveryError(ConfigurationMissingKey):
+    """Raised when configuration is missing and cannot be discovery."""
+
+
+class OIDCDiscovery:
+    """Helper class for using the OIDC discovery mechanism.
+
+    Configuration is only checked and data fetched over the network if needed,
+    and all network requests are cached.
+    """
+
+    _authority_url: Optional[str]
+
+    def __init__(self, authority_url: str):
+        """Initialize with the authority URL."""
+        if not authority_url or not authority_url.startswith("https://"):
+            self._authority_url = None
+        else:
+            if not authority_url.endswith("/"):
+                authority_url += "/"
+            self._authority_url = authority_url
+
+    @property
+    def authority_url(self) -> str:
+        """Get the authority URL with a trailing slash."""
+        authority_url = self._authority_url
+        if authority_url is None:
+            raise ConfigurationMissingKey("No valid OIDC authority URL configured")
+        return authority_url
+
+    @property
+    def config_url(self) -> str:
+        """Get the URL for the configuration."""
+        return self.authority_url + ".well-known/openid-configuration"
+
+    @cached_property
+    def config(self) -> dict[str, Any]:
+        """Fetch the OIDC configuration directory."""
+        respsonse = httpx.get(self.config_url, timeout=TIMEOUT)
+        config = respsonse.json()
+        if not isinstance(config, dict) or "version" not in config:
+            raise ConfigurationDiscoveryError("Unexpected discovery object")
+        return config
+
+    @cached_property
+    def jwks_str(self) -> str:
+        """Fetch the JSON string with the JWKS."""
+        jwks_uri = self.config.get("jwks_uri")
+        if not jwks_uri or not isinstance(jwks_uri, str):
+            raise ConfigurationDiscoveryError("Cannot discover JWKS URI")
+        if not jwks_uri.startswith(self.authority_url):
+            raise ConfigurationDiscoveryError("Unexpected JWKS URI")
+        jwks_response = httpx.get(jwks_uri, timeout=TIMEOUT)
+        jwks_dict = jwks_response.json()
+        if not isinstance(jwks_dict, dict) or "keys" not in jwks_dict:
+            raise ConfigurationDiscoveryError("Unexpected JWKS object")
+        return jwks_response.text
+
+    @property
+    def token_endpoint(self) -> str:
+        """Fetch the URL of the token endpoint."""
+        token_endpoint = self.config.get("token_endpoint")
+        if not token_endpoint or not isinstance(token_endpoint, str):
+            raise ConfigurationDiscoveryError("Cannot discover token endpoint")
+        return token_endpoint
+
+    @property
+    def userinfo_endpoint(self) -> str:
+        """Fetch the URL of the userinfo endpoint."""
+        userinfo_endpoint = self.config.get("userinfo_endpoint")
+        if not userinfo_endpoint or not isinstance(userinfo_endpoint, str):
+            raise ConfigurationDiscoveryError("Cannot discover userinfo endpoint")
+        return userinfo_endpoint
+
+
 class JWTConfig:
     """A container for the JWT related configuration."""
 
     external_jwks: jwk.JWKSet  # the external public key set
     internal_jwk: jwk.JWK  # the internal key pair
     external_algs: Optional[list[str]] = None  # allowed external signing algorithms
-    check_claims: dict[str, Any] = {  # claims that shall be verified
+    check_at_claims: dict[str, Any] = {  # access token claims that shall be verified
         "iat": None,
         "exp": None,
         "jti": None,
         "sub": None,
-        "name": None,
-        "email": None,
         "token_class": "access_token",
     }
-    # the claims that are copied from the external to the internal token
-    copied_claims = ("name", "email", "iat", "exp")
+    check_ui_claims: dict[str, Any] = {  # userinfo claims that shall be verified
+        "sub": None,
+        "name": None,
+        "email": None,
+    }
+    # the claims that are copied from the external access token to the internal token
+    copy_at_claims = ("iat", "exp")
+    # the claims that are copied from the external userinfo to the internal token
+    copy_ui_claims = ("name", "email")
     # the key under which the subject is copied from the external token
     copy_sub_as = "ext_id"
+    userinfo_endpoint: str
 
     def __init__(self, config: Config = CONFIG) -> None:
         """Load the JWT related configuration parameters."""
+        discovery = OIDCDiscovery(config.oidc_authority_url)
 
         external_keys = config.auth_ext_keys
         if not external_keys:
-            raise ConfigurationMissingKey("No external signing keys configured.")
+            log.warning("No external signing keys configured, using discovery.")
+            external_keys = discovery.jwks_str
         external_jwks = jwk.JWKSet.from_json(external_keys)
         if not any(external_jwk.has_public for external_jwk in external_jwks):
             raise ConfigurationMissingKey("No public external signing keys found.")
@@ -105,19 +197,33 @@ class JWTConfig:
         else:
             log.warning("Allowed external signing algorithms not configured.")
             self.external_algs = None
-        authority_url = config.oidc_authority_url
-        if authority_url:
-            self.check_claims["iss"] = authority_url
-        else:
-            log.warning("No OIDC authority URL configured.")
+        self.check_at_claims["iss"] = discovery.authority_url[:-1]
         client_id = config.oidc_client_id
         if client_id:
-            self.check_claims["client_id"] = client_id
+            self.check_at_claims["client_id"] = client_id
         else:
             log.warning("No OIDC client ID configured.")
 
+        userinfo_endpoint = config.oidc_userinfo_endpoint
+        if not userinfo_endpoint:
+            log.warning("No external userinfo endpoint configured, using discovery.")
+            userinfo_endpoint = discovery.userinfo_endpoint
+        self.userinfo_endpoint = userinfo_endpoint
+
 
 jwt_config = JWTConfig()
+
+
+@lru_cache(maxsize=1024)
+def fetch_user_info(access_token: str) -> dict[str, Any]:
+    """Fetch info for the given access token from the userinfo endpoint."""
+    response = httpx.get(
+        jwt_config.userinfo_endpoint,
+        headers={"Authorization": f"Bearer {access_token}"},
+    )
+    if response.status_code != status.HTTP_200_OK:
+        raise UserInfoError(f"Cannot request userinfo: {response.reason_phrase}")
+    return response.json()
 
 
 def _user_data_matches(user: User, external_claims: dict[str, Any]) -> bool:
@@ -137,11 +243,12 @@ async def exchange_token(
     If the provided external token is valid, a corresponding internal token
     will be returned.
 
-    The internal token will contain the name and email taken from the
-    external token, and also its issued date and expiry date.
-    If the user is already registered, the user id and status will be
+    The internal token will contain relevant claims from the access token and
+    the user info as configured.
+
+    If the user is already registered, the user id, status and title will be
     included in the internal token as well.
-    If name or email do not match with the external token, the user status
+    If name or email do not match with the external userinfo, the user status
     will appear as "invalid" in the internal token, but the actual status
     will not  be changed in the user registry.
     If the user is not yet registered, and pass_sub is set, then the sub claim
@@ -150,29 +257,35 @@ async def exchange_token(
     If the user has a special internal role, this is passed as the "role"
     claim of the internal token.
 
-    If the external token is invalid a TokenValidationError is raised.
+    If the external token is invalid, a TokenValidationError is raised.
+    If the user info cannot be requested, a UserInfoError is raised.
     If the internal token cannot be signed, a TokenSigningError is raised.
     """
-    external_claims = decode_and_validate_token(external_token)
-    internal_claims = {
-        claim: external_claims[claim] for claim in jwt_config.copied_claims
-    }
-    sub = external_claims["sub"]
+    at_claims = decode_and_validate_token(external_token)
+    _assert_at_claims_not_empty(at_claims)
+    sub = at_claims["sub"]
     try:
         user = await user_dao.find_one(mapping={"ext_id": sub})
     except NoHitsFoundError:
         # user is not yet registered
         if not pass_sub:
             return None
-    else:
+        user = None
+    ui_claims = fetch_user_info(external_token)
+    _assert_ui_claims_not_empty(ui_claims)
+    if ui_claims["sub"] != sub:
+        raise UserInfoError("Subject in userinfo differs from access token.")
+    copy_claims = jwt_config.copy_at_claims
+    internal_claims = {claim: at_claims[claim] for claim in copy_claims}
+    copy_claims = jwt_config.copy_ui_claims
+    internal_claims.update({claim: ui_claims[claim] for claim in copy_claims})
+    if user:
         # user already exists in the registry
-        status = (
-            user.status
-            if _user_data_matches(user, external_claims)
-            else UserStatus.INVALID
+        user_status = (
+            user.status if _user_data_matches(user, ui_claims) else UserStatus.INVALID
         )
-        internal_claims.update(id=user.id, status=status)
-        if status is UserStatus.ACTIVE and await is_data_steward(
+        internal_claims.update(id=user.id, status=user_status, title=user.title)
+        if user_status is UserStatus.ACTIVE and await is_data_steward(
             user.id, user_dao=user_dao, claim_dao=claim_dao
         ):
             internal_claims.update(role="data_steward")
@@ -181,19 +294,27 @@ async def exchange_token(
     return sign_and_encode_token(internal_claims)
 
 
-def _assert_claims_not_empty(claims: dict[str, Any]) -> None:
-    """Make sure that all important claims are not empty.
+def _assert_at_claims_not_empty(at_claims: dict[str, Any]) -> None:
+    """Make sure that all important access token claims are not empty.
 
     Note that JWT.validate() checks only whether claims exist, but we also
     want to make sure that the copied claims are not null or empty strings.
 
     Raises a TokenValidationError in case one of the claims is empty.
     """
-    if not claims["sub"]:
-        raise TokenValidationError("The subject claim is missing.")
-    for claim in jwt_config.copied_claims:
-        if not claims[claim]:
+    for claim in jwt_config.check_at_claims:
+        if not at_claims[claim]:
             raise TokenValidationError(f"Missing value for {claim} claim.")
+
+
+def _assert_ui_claims_not_empty(ui_claims: dict[str, Any]) -> None:
+    """Make sure that all important user info claims are not empty.
+
+    Raises a UserInfoError in case one of the claims is empty.
+    """
+    for claim in jwt_config.check_ui_claims:
+        if not ui_claims.get(claim):
+            raise UserInfoError(f"Missing value for {claim} claim.")
 
 
 def decode_and_validate_token(
@@ -212,17 +333,15 @@ def decode_and_validate_token(
             jwt=access_token,
             key=key,
             algs=jwt_config.external_algs,
-            check_claims=jwt_config.check_claims,
+            check_claims=jwt_config.check_at_claims,
             expected_type="JWS",
         )
     except (JWException, UnicodeDecodeError, KeyError, TypeError, ValueError) as exc:
         raise TokenValidationError(f"Not a valid token: {exc}") from exc
     try:
-        claims = json.loads(token.claims)
+        return json.loads(token.claims)
     except json.JSONDecodeError as exc:
         raise TokenValidationError("Claims cannot be decoded") from exc
-    _assert_claims_not_empty(claims)
-    return claims
 
 
 def sign_and_encode_token(

--- a/auth_service/config.py
+++ b/auth_service/config.py
@@ -82,6 +82,7 @@ class Config(ApiConfigBase):
 
     # expected external token content for validation in auth adapter
     oidc_authority_url: str = "https://proxy.aai.lifescience-ri.eu"
+    oidc_userinfo_endpoint: Optional[str] = oidc_authority_url + "/OIDC/userinfo"
     oidc_client_id: str = "ghga-data-portal"
 
     # the URL used as source for internal claims

--- a/config_schema.json
+++ b/config_schema.json
@@ -217,6 +217,14 @@
       ],
       "type": "string"
     },
+    "oidc_userinfo_endpoint": {
+      "title": "Oidc Userinfo Endpoint",
+      "default": "https://proxy.aai.lifescience-ri.eu/OIDC/userinfo",
+      "env_names": [
+        "auth_service_oidc_userinfo_endpoint"
+      ],
+      "type": "string"
+    },
     "oidc_client_id": {
       "title": "Oidc Client Id",
       "default": "ghga-data-portal",

--- a/example_config.yaml
+++ b/example_config.yaml
@@ -3,17 +3,20 @@ api_root_path: /
 auth_ext_algs:
 - RS256
 - ES256
-auth_ext_keys: null
-auth_int_keys: null
+auth_ext_keys: ''
+auth_int_keys: '{"crv":"P-256","d":"j_PWLv4oCixBy7FOXtENVGTS0v4uc5mMb8FA9FOfnRc","kty":"EC","x":"Q-aCZxdOdZD6zxvuvPbGmDWUV3IhqkMX6Yd1lbHjWEs","y":"uzBoSha4mMuEtU_Tag1l_NekUYq5dikoob3x4bEoTrg"}'
 auto_reload: true
 basic_auth_pwd: null
 basic_auth_realm: GHGA Data Portal
 basic_auth_user: null
 claims_collection: claims
-cors_allow_credentials: null
-cors_allowed_headers: null
-cors_allowed_methods: null
-cors_allowed_origins: null
+cors_allow_credentials: true
+cors_allowed_headers:
+- '*'
+cors_allowed_methods:
+- '*'
+cors_allowed_origins:
+- '*'
 db_name: user-management
 db_url: mongodb://mongodb:27017/
 docs_url: /docs
@@ -21,10 +24,11 @@ host: 0.0.0.0
 log_level: debug
 oidc_authority_url: https://proxy.aai.lifescience-ri.eu
 oidc_client_id: ghga-data-portal
+oidc_userinfo_endpoint: https://proxy.aai.lifescience-ri.eu/OIDC/userinfo
 openapi_url: /openapi.json
 organization_url: https://ghga.de
-port: 8080
-run_auth_adapter: false
+port: 9000
+run_auth_adapter: true
 service_name: auth_service
 users_collection: users
 workers: 1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,3 +4,4 @@
 
 # additional requirements can be listed here
 testcontainers[mongo]==3.4.1
+pytest_httpx==0.12.3

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,6 +39,7 @@ install_requires =
     hexkit[mongodb]==0.9.2
     pydantic[email]==1.10.6
     jwcrypto==1.4.2
+    httpx==0.23.3
 
 python_requires = >= 3.9
 
@@ -47,13 +48,7 @@ console_scripts =
     auth-service = auth_service.__main__:run
 
 [options.extras_require]
-dev =
-    hexkit[dev]==0.9.2
-    httpx==0.23.3
-    typer==0.7.0
-
 all =
-    %(dev)s
 
 [options.packages.find]
 exclude = tests

--- a/tests/fixtures/auth_keys.py
+++ b/tests/fixtures/auth_keys.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #

--- a/tests/integration/auth_adapter/test_api.py
+++ b/tests/integration/auth_adapter/test_api.py
@@ -15,10 +15,12 @@
 
 """Test the api module"""
 
+import re
 from base64 import b64encode
 
 from fastapi import status
 from ghga_service_chassis_lib.utils import now_as_utc
+from pytest import fixture
 
 from auth_service.auth_adapter.api.headers import get_bearer_token
 from auth_service.config import CONFIG
@@ -41,6 +43,19 @@ API_EXT_PATH = CONFIG.api_ext_path.strip("/")
 if API_EXT_PATH:
     API_EXT_PATH += "/"
 USERS_PATH = f"/{API_EXT_PATH}users"
+
+USER_INFO = {
+    "name": "John Doe",
+    "email": "john@home.org",
+    "sub": "john@aai.org",
+}
+RE_USER_INFO_URL = re.compile(".*/userinfo$")
+
+
+@fixture
+def non_mocked_hosts() -> list:
+    """Do not mock requests to the test server."""
+    return ["testserver"]
 
 
 def test_get_from_root(client):
@@ -212,9 +227,11 @@ def test_does_not_authorize_invalid_users(client):
 
 
 def test_token_exchange_for_unknown_user(
-    client,
+    client, httpx_mock
 ):  # pylint:disable=too-many-statements
     """Test the token exchange for authenticated but unknown users."""
+
+    httpx_mock.add_response(url=RE_USER_INFO_URL, json=USER_INFO)
 
     user_dao = DummyUserDao(ext_id="not.john@aai.org")
     client.app.dependency_overrides[get_user_dao] = lambda: user_dao
@@ -317,7 +334,7 @@ def test_token_exchange_for_unknown_user(
 
 
 def test_token_exchange_for_known_user(
-    client,
+    client, httpx_mock
 ):  # pylint:disable=too-many-statements
     """Test the token exchange for authenticated and registered users."""
 
@@ -331,6 +348,8 @@ def test_token_exchange_for_known_user(
     assert user.status_change is None
 
     # Check that we get an internal token for the user
+
+    httpx_mock.add_response(url=RE_USER_INFO_URL, json=USER_INFO)
 
     auth = f"Bearer {create_access_token()}"
     response = client.get("/some/path", headers={"Authorization": auth})
@@ -347,20 +366,25 @@ def test_token_exchange_for_known_user(
     assert internal_token
     claims = get_claims_from_token(internal_token)
     assert isinstance(claims, dict)
-    expected_claims = {"id", "name", "email", "status", "exp", "iat"}
+    expected_claims = {"id", "name", "email", "status", "title", "exp", "iat"}
 
     assert set(claims) == expected_claims
     assert claims["id"] == user.id
     assert claims["name"] == user.name
     assert claims["email"] == user.email
     assert claims["status"] == "active"
+    assert claims["title"] is None
     assert isinstance(claims["iat"], int)
     assert isinstance(claims["exp"], int)
     assert claims["iat"] <= int(now_as_utc().timestamp()) < claims["exp"]
 
     # Check that the user becomes invalid when the name has changed
 
-    auth = f"Bearer {create_access_token(name='John Foo')}"
+    httpx_mock.add_response(
+        url=RE_USER_INFO_URL, json={**USER_INFO, "name": "John Foo"}
+    )
+
+    auth = f"Bearer {create_access_token()}"
     response = client.get("/some/path", headers={"Authorization": auth})
 
     assert response.status_code == status.HTTP_200_OK
@@ -375,20 +399,25 @@ def test_token_exchange_for_known_user(
     assert internal_token
     claims = get_claims_from_token(internal_token)
     assert isinstance(claims, dict)
-    expected_claims = {"id", "name", "email", "status", "exp", "iat"}
+    expected_claims = {"id", "name", "email", "status", "title", "exp", "iat"}
 
     assert set(claims) == expected_claims
     assert claims["id"] == user.id
     assert claims["name"] == "John Foo"  # changed name in internal token
     assert claims["email"] == user.email
     assert claims["status"] == "invalid"  # because there is a name mismatch
+    assert claims["title"] is None
     assert isinstance(claims["iat"], int)
     assert isinstance(claims["exp"], int)
     assert claims["iat"] <= int(now_as_utc().timestamp()) < claims["exp"]
 
     # Check that the user becomes invalid when the mail has changed
 
-    auth = f"Bearer {create_access_token(email='john@foo.org')}"
+    httpx_mock.add_response(
+        url=RE_USER_INFO_URL, json={**USER_INFO, "email": "john@foo.org"}
+    )
+
+    auth = f"Bearer {create_access_token()}"
     response = client.get("/some/path", headers={"Authorization": auth})
 
     assert response.status_code == status.HTTP_200_OK
@@ -403,13 +432,14 @@ def test_token_exchange_for_known_user(
     assert internal_token
     claims = get_claims_from_token(internal_token)
     assert isinstance(claims, dict)
-    expected_claims = {"id", "name", "email", "status", "exp", "iat"}
+    expected_claims = {"id", "name", "email", "status", "title", "exp", "iat"}
 
     assert set(claims) == expected_claims
     assert claims["id"] == user.id
     assert claims["name"] == user.name
     assert claims["email"] == "john@foo.org"  # changed mail in internal token
     assert claims["status"] == "invalid"  # because there is a name mismatch
+    assert claims["title"] is None
     assert isinstance(claims["iat"], int)
     assert isinstance(claims["exp"], int)
     assert claims["iat"] <= int(now_as_utc().timestamp()) < claims["exp"]
@@ -421,8 +451,10 @@ def test_token_exchange_for_known_user(
     assert user.status_change is None
 
 
-def test_token_exchange_with_x_token(client):
+def test_token_exchange_with_x_token(client, httpx_mock):
     """Test that the external access token can be passed in separate header."""
+
+    httpx_mock.add_response(url=RE_USER_INFO_URL, json=USER_INFO)
 
     user_dao = DummyUserDao(ext_id="not.john@aai.org")
     client.app.dependency_overrides[get_user_dao] = lambda: user_dao
@@ -466,12 +498,14 @@ def test_token_exchange_with_x_token(client):
 
 
 def test_token_exchange_for_known_data_steward(
-    client,
+    client, httpx_mock
 ):  # pylint:disable=too-many-statements
     """Test the token exchange for an authenticated data steward."""
 
+    httpx_mock.add_response(url=RE_USER_INFO_URL, json=USER_INFO)
+
     # add a dummy user who is a data steward
-    user_dao: UserDao = DummyUserDao(id_="james@ghga.de")
+    user_dao: UserDao = DummyUserDao(id_="james@ghga.de", title="Dr.")
     client.app.dependency_overrides[get_user_dao] = lambda: user_dao
     claim_dao: ClaimDao = DummyClaimDao()
     client.app.dependency_overrides[get_claim_dao] = lambda: claim_dao
@@ -489,12 +523,13 @@ def test_token_exchange_for_known_data_steward(
     assert internal_token
     claims = get_claims_from_token(internal_token)
     assert isinstance(claims, dict)
-    expected_claims = {"id", "name", "email", "status", "exp", "iat", "role"}
+    expected_claims = {"id", "name", "email", "status", "title", "exp", "iat", "role"}
 
     assert set(claims) == expected_claims
     assert claims["id"] == user.id
     assert claims["name"] == user.name
     assert claims["email"] == user.email
+    assert claims["title"] == "Dr."
     assert claims["status"] == "active"
 
     # check that the data steward role appears in the token

--- a/tests/integration/auth_adapter/test_oidc_discovery.py
+++ b/tests/integration/auth_adapter/test_oidc_discovery.py
@@ -12,24 +12,28 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+#
 
-"""Entrypoint of the package"""
+"""Test the OIDC Discovery helper class."""
 
-import asyncio
+from auth_service.auth_adapter.core.auth import OIDCDiscovery
 
-from ghga_service_chassis_lib.api import run_server
-from ghga_service_chassis_lib.utils import assert_tz_is_utc
-
-from .config import CONFIG, Config
+LS_AAI = "https://proxy.aai.lifescience-ri.eu"
 
 
-def run(config: Config = CONFIG):
-    """Run the service"""
-    assert_tz_is_utc()
-    service = "auth_adapter" if config.run_auth_adapter else "user_management"
-    print(f"Starting {service} service")
-    asyncio.run(run_server(app=f"auth_service.{service}.api.main:app", config=config))
+def test_ls_aai_jwks_str():
+    """Test the JWKS discovery."""
+    discovery = OIDCDiscovery(LS_AAI)
+    assert discovery.jwks_str.startswith('{"keys": [{')
 
 
-if __name__ == "__main__":
-    run()
+def test_ls_aai_token_endpoint():
+    """Test the userinfo endpoint discovery."""
+    discovery = OIDCDiscovery(LS_AAI)
+    assert discovery.token_endpoint == LS_AAI + "/OIDC/token"
+
+
+def test_ls_aai_userinfo_endpoint():
+    """Test the userinfo endpoint discovery."""
+    discovery = OIDCDiscovery(LS_AAI)
+    assert discovery.userinfo_endpoint == LS_AAI + "/OIDC/userinfo"

--- a/tests/unit/auth_adapter/test_token_exchange.py
+++ b/tests/unit/auth_adapter/test_token_exchange.py
@@ -16,11 +16,17 @@
 
 """Unit tests for the auth adapter core token exchange feature"""
 
+import re
+
 from ghga_service_chassis_lib.utils import now_as_utc
+from pydantic import EmailStr
 from pytest import mark, raises
 
 from auth_service.auth_adapter.core import auth
-from auth_service.user_management.user_registry.models.dto import UserStatus
+from auth_service.user_management.user_registry.models.dto import (
+    AcademicTitle,
+    UserStatus,
+)
 
 from ...fixtures.utils import (
     DummyClaimDao,
@@ -28,6 +34,13 @@ from ...fixtures.utils import (
     create_access_token,
     get_claims_from_token,
 )
+
+USER_INFO = {
+    "name": "John Doe",
+    "email": "john@home.org",
+    "sub": "john@aai.org",
+}
+RE_USER_INFO_URL = re.compile(".*/userinfo$")
 
 
 @mark.asyncio
@@ -39,10 +52,68 @@ async def test_rejects_an_expired_access_token():
 
 
 @mark.asyncio
-async def test_exchanges_token_for_unknown_user_if_requested():
+async def test_rejects_an_access_token_without_sub():
+    """Test the token exchange for a token with missing subject."""
+    access_token = create_access_token(sub=None)
+    with raises(auth.TokenValidationError, match="Missing value for sub claim"):
+        await auth.exchange_token(access_token)
+
+
+@mark.asyncio
+async def test_rejects_an_access_token_with_bad_token_class():
+    """Test the token exchange for a token with an unexpected token class."""
+    access_token = create_access_token(token_class="foo_token")
+    with raises(
+        auth.TokenValidationError,
+        match=r"Not a valid token: Invalid 'token_class' value\."
+        " Expected 'access_token' got 'foo_token'",
+    ):
+        await auth.exchange_token(access_token)
+
+
+@mark.asyncio
+async def test_rejects_user_info_with_mismatch_in_sub(httpx_mock):
+    """Test the token exchange for a mismatch in subject claims."""
+    access_token = create_access_token()
+    user_dao = DummyUserDao(ext_id=EmailStr("not.john@aai.org"))
+    httpx_mock.add_response(
+        url=RE_USER_INFO_URL, json={**USER_INFO, "sub": "john@foo.org"}
+    )
+    with raises(
+        auth.UserInfoError,
+        match="Subject in userinfo differs from access token",
+    ):
+        await auth.exchange_token(access_token, pass_sub=True, user_dao=user_dao)
+
+
+@mark.asyncio
+async def test_rejects_user_info_with_missing_name(httpx_mock):
+    """Test the token exchange for a missing name in user info."""
+    access_token = create_access_token()
+    user_dao = DummyUserDao(ext_id=EmailStr("not.john@aai.org"))
+    user_info = {**USER_INFO, "name": None}  # type: ignore
+    httpx_mock.add_response(url=RE_USER_INFO_URL, json=user_info)
+    with raises(auth.UserInfoError, match="Missing value for name claim"):
+        await auth.exchange_token(access_token, pass_sub=True, user_dao=user_dao)
+
+
+@mark.asyncio
+async def test_rejects_user_info_with_missing_email(httpx_mock):
+    """Test the token exchange for a missing email in user info."""
+    access_token = create_access_token()
+    user_dao = DummyUserDao(ext_id=EmailStr("not.john@aai.org"))
+    user_info = {**USER_INFO, "email": None}  # type: ignore
+    httpx_mock.add_response(url=RE_USER_INFO_URL, json=user_info)
+    with raises(auth.UserInfoError, match="Missing value for email claim"):
+        await auth.exchange_token(access_token, pass_sub=True, user_dao=user_dao)
+
+
+@mark.asyncio
+async def test_exchanges_token_for_unknown_user_if_requested(httpx_mock):
     """Test token exchange for a valid but unknown user with pass_sub flag."""
     access_token = create_access_token()
     user_dao = DummyUserDao(ext_id="not.john@aai.org")
+    httpx_mock.add_response(url=RE_USER_INFO_URL, json=USER_INFO)
     internal_token = await auth.exchange_token(
         access_token, pass_sub=True, user_dao=user_dao
     )
@@ -63,27 +134,29 @@ async def test_exchanges_token_for_unknown_user_if_requested():
 async def test_does_not_exchange_for_unknown_user_if_not_requested():
     """Test token exchange for a valid but unknown user without pass_sub flag."""
     access_token = create_access_token()
-    user_dao = DummyUserDao(ext_id="not.john@aai.org")
+    user_dao = DummyUserDao(ext_id=EmailStr("not.john@aai.org"))
     assert await auth.exchange_token(access_token, user_dao=user_dao) is None
 
 
 @mark.asyncio
-async def test_exchanges_access_token_for_a_known_user():
+async def test_exchanges_access_token_for_a_known_user(httpx_mock):
     """Test the token exchange for a valid and already known user."""
     access_token = create_access_token()
     user_dao, claim_dao = DummyUserDao(), DummyClaimDao()
+    httpx_mock.add_response(url=RE_USER_INFO_URL, json=USER_INFO)
     internal_token = await auth.exchange_token(
         access_token, user_dao=user_dao, claim_dao=claim_dao
     )
     assert internal_token is not None
     claims = get_claims_from_token(internal_token)
     assert isinstance(claims, dict)
-    expected_claims = {"email", "name", "id", "status", "exp", "iat"}
+    expected_claims = {"email", "name", "id", "status", "title", "exp", "iat"}
     assert set(claims) == expected_claims
     assert claims["name"] == "John Doe"
     assert claims["email"] == "john@home.org"
     assert claims["id"] == "john@ghga.de"
     assert claims["status"] == "active"
+    assert claims["title"] is None
     assert isinstance(claims["iat"], int)
     assert isinstance(claims["exp"], int)
     assert claims["iat"] <= int(now_as_utc().timestamp()) < claims["exp"]
@@ -92,10 +165,11 @@ async def test_exchanges_access_token_for_a_known_user():
 
 
 @mark.asyncio
-async def test_also_passes_sub_for_a_known_user():
+async def test_also_passes_sub_for_a_known_user(httpx_mock):
     """Test that the sub claim is also passed for an already known user."""
     access_token = create_access_token()
     user_dao, claim_dao = DummyUserDao(), DummyClaimDao()
+    httpx_mock.add_response(url=RE_USER_INFO_URL, json=USER_INFO)
     internal_token = await auth.exchange_token(
         access_token, pass_sub=True, user_dao=user_dao, claim_dao=claim_dao
     )
@@ -107,20 +181,22 @@ async def test_also_passes_sub_for_a_known_user():
 
 
 @mark.asyncio
-async def test_exchanges_access_token_when_name_was_changed():
+async def test_exchanges_access_token_when_name_was_changed(httpx_mock):
     """Test the token exchange for a valid user with a different name."""
     access_token = create_access_token()
     user_dao = DummyUserDao(name="John Foo")
+    httpx_mock.add_response(url=re.compile(".*/userinfo$"), json=USER_INFO)
     internal_token = await auth.exchange_token(access_token, user_dao=user_dao)
     assert internal_token is not None
     claims = get_claims_from_token(internal_token)
     assert isinstance(claims, dict)
-    expected_claims = {"email", "name", "id", "status", "exp", "iat"}
+    expected_claims = {"email", "name", "id", "status", "title", "exp", "iat"}
     assert set(claims) == expected_claims
     assert claims["name"] == "John Doe"
     assert claims["email"] == "john@home.org"
     assert claims["id"] == "john@ghga.de"
     assert claims["status"] == "invalid"
+    assert claims["title"] is None
     assert isinstance(claims["iat"], int)
     assert isinstance(claims["exp"], int)
     assert claims["iat"] <= int(now_as_utc().timestamp()) < claims["exp"]
@@ -130,20 +206,22 @@ async def test_exchanges_access_token_when_name_was_changed():
 
 
 @mark.asyncio
-async def test_exchanges_access_token_when_email_was_changed():
+async def test_exchanges_access_token_when_email_was_changed(httpx_mock):
     """Test the token exchange for a valid user with a different email."""
     access_token = create_access_token()
-    user_dao = DummyUserDao(email="john@elsewhere.org")
+    user_dao = DummyUserDao(email=EmailStr("john@elsewhere.org"))
+    httpx_mock.add_response(url=RE_USER_INFO_URL, json=USER_INFO)
     internal_token = await auth.exchange_token(access_token, user_dao=user_dao)
     assert internal_token is not None
     claims = get_claims_from_token(internal_token)
     assert isinstance(claims, dict)
-    expected_claims = {"email", "name", "id", "status", "exp", "iat"}
+    expected_claims = {"email", "name", "id", "status", "title", "exp", "iat"}
     assert set(claims) == expected_claims
     assert claims["name"] == "John Doe"
     assert claims["email"] == "john@home.org"
     assert claims["id"] == "john@ghga.de"
     assert claims["status"] == "invalid"
+    assert claims["title"] is None
     assert isinstance(claims["iat"], int)
     assert isinstance(claims["exp"], int)
     assert claims["iat"] <= int(now_as_utc().timestamp()) < claims["exp"]
@@ -153,39 +231,48 @@ async def test_exchanges_access_token_when_email_was_changed():
 
 
 @mark.asyncio
-async def test_adds_role_for_a_known_data_steward():
+async def test_adds_role_for_a_known_data_steward(httpx_mock):
     """Test that the internal token contains the role for a data steward."""
     access_token = create_access_token()
-    user_dao, claim_dao = (DummyUserDao(id_="james@ghga.de"), DummyClaimDao())
+    user_dao, claim_dao = (
+        DummyUserDao(id_="james@ghga.de", title=AcademicTitle.DR),
+        DummyClaimDao(),
+    )
+    httpx_mock.add_response(url=RE_USER_INFO_URL, json=USER_INFO)
     internal_token = await auth.exchange_token(
         access_token, user_dao=user_dao, claim_dao=claim_dao
     )
     assert internal_token is not None
     claims = get_claims_from_token(internal_token)
     assert isinstance(claims, dict)
-    expected_claims = {"email", "name", "id", "status", "exp", "iat", "role"}
+    expected_claims = {"email", "name", "id", "status", "title", "exp", "iat", "role"}
     assert set(claims) == expected_claims
     assert claims["id"] == "james@ghga.de"
     assert claims["status"] == "active"
+    assert claims["title"] == "Dr."
 
     assert claims["role"] == "data_steward"
 
 
 @mark.asyncio
-async def test_does_not_add_role_for_a_known_inactive_data_steward():
+async def test_does_not_add_role_for_a_known_inactive_data_steward(httpx_mock):
     """Test that the token does not contain the role for an inactive data steward."""
     access_token = create_access_token()
     user_dao, claim_dao = (
-        DummyUserDao(id_="james@ghga.de", status=UserStatus.INACTIVE),
+        DummyUserDao(
+            id_="james@ghga.de", title=AcademicTitle.DR, status=UserStatus.INACTIVE
+        ),
         DummyClaimDao(),
     )
+    httpx_mock.add_response(url=RE_USER_INFO_URL, json=USER_INFO)
     internal_token = await auth.exchange_token(
         access_token, user_dao=user_dao, claim_dao=claim_dao
     )
     assert internal_token is not None
     claims = get_claims_from_token(internal_token)
     assert isinstance(claims, dict)
-    expected_claims = {"email", "name", "id", "status", "exp", "iat"}
+    expected_claims = {"email", "name", "id", "status", "title", "exp", "iat"}
     assert set(claims) == expected_claims
     assert claims["id"] == "james@ghga.de"
     assert claims["status"] == "inactive"
+    assert claims["title"] == "Dr."

--- a/tests/unit/auth_adapter/test_token_validation.py
+++ b/tests/unit/auth_adapter/test_token_validation.py
@@ -18,7 +18,7 @@
 
 from ghga_service_chassis_lib.utils import now_as_utc
 from jwcrypto import jwk
-from pytest import mark, raises
+from pytest import raises
 
 from auth_service.auth_adapter.core import auth
 from auth_service.config import CONFIG
@@ -33,20 +33,16 @@ def test_decodes_and_validates_a_valid_access_token():
     assert isinstance(claims, dict)
     assert set(claims) == {
         "client_id",
-        "email",
         "exp",
         "foo",
         "iat",
         "iss",
         "jti",
-        "name",
         "sub",
         "token_class",
     }
     assert claims["client_id"] == CONFIG.oidc_client_id
     assert claims["iss"] == CONFIG.oidc_authority_url
-    assert claims["name"] == "John Doe"
-    assert claims["email"] == "john@home.org"
     assert claims["jti"] == "123-456-789-0"
     assert claims["sub"] == "john@aai.org"
     assert claims["foo"] == "bar"
@@ -62,7 +58,7 @@ def test_validates_access_token_with_rsa_signature():
     access_token = create_access_token(key=key)
     claims = auth.decode_and_validate_token(access_token, key=key)
     assert isinstance(claims, dict)
-    assert claims["name"] == "John Doe"
+    assert claims["sub"] == "john@aai.org"
 
 
 def test_validates_access_token_with_ec_signature():
@@ -71,7 +67,7 @@ def test_validates_access_token_with_ec_signature():
     access_token = create_access_token(key=key)
     claims = auth.decode_and_validate_token(access_token, key=key)
     assert isinstance(claims, dict)
-    assert claims["name"] == "John Doe"
+    assert claims["sub"] == "john@aai.org"
 
 
 def test_does_not_validate_an_empty_token():
@@ -132,33 +128,6 @@ def test_does_not_validate_an_access_token_with_invalid_issuer():
         " Expected 'https://proxy.aai.lifescience-ri.eu'"
         " got 'https://proxy.aai.badscience-ri.eu'"
     )
-
-
-@mark.parametrize("empty_claim", [None, ""])
-def test_does_not_validate_an_access_token_with_missing_subject(empty_claim):
-    """Test that an access token with a missing subject is rejected."""
-    access_token = create_access_token(sub=empty_claim)
-    with raises(auth.TokenValidationError) as exc_info:
-        auth.decode_and_validate_token(access_token)
-    assert str(exc_info.value) == "The subject claim is missing."
-
-
-@mark.parametrize("empty_claim", [None, ""])
-def test_does_not_validate_an_access_token_with_missing_name(empty_claim):
-    """Test that an access token with a missing name is rejected."""
-    access_token = create_access_token(name=empty_claim)
-    with raises(auth.TokenValidationError) as exc_info:
-        auth.decode_and_validate_token(access_token)
-    assert str(exc_info.value) == "Missing value for name claim."
-
-
-@mark.parametrize("empty_claim", [None, ""])
-def test_does_not_validate_an_access_token_with_missing_email(empty_claim):
-    """Test that an access token with a missing email is rejected."""
-    access_token = create_access_token(email=empty_claim)
-    with raises(auth.TokenValidationError) as exc_info:
-        auth.decode_and_validate_token(access_token)
-    assert str(exc_info.value) == "Missing value for email claim."
 
 
 def test_does_not_validate_an_expired_access_token():


### PR DESCRIPTION
Instead of taking user data from the access token, request them from the userinfo endpoint.

The existence of the data in the access token was an undocumented feature which is not supported any more.