### PR TITLE
Allow head requests from well-known path

### DIFF
--- a/auth_service/auth_adapter/api/main.py
+++ b/auth_service/auth_adapter/api/main.py
@@ -46,26 +46,28 @@ app = FastAPI(title=TITLE, description=DESCRIPTION, version=VERSION)
 configure_app(app, config=CONFIG)
 
 # the auth adapter needs to handle all HTTP methods
-HANDLE_METHODS = ["GET", "POST", "PUT", "DELETE", "OPTIONS", "HEAD", "PATCH"]
+READ_METHODS = ["GET", "HEAD", "OPTIONS"]
+WRITE_METHODS = ["POST", "PUT", "PATCH", "DELETE"]
+ALL_METHODS = READ_METHODS + WRITE_METHODS
 
 API_EXT_PATH = CONFIG.api_ext_path.strip("/")
 if API_EXT_PATH:
     API_EXT_PATH += "/"
 
 
-@app.api_route("/.well-known/{path:path}", methods=["GET"])
+@app.api_route("/.well-known/{path:path}", methods=READ_METHODS)
 async def ext_auth_well_known() -> dict:
     """Unprotected route for the .well-known URLs."""
     return {}
 
 
-@app.api_route("/service-logo.png", methods=["GET"])
+@app.api_route("/service-logo.png", methods=READ_METHODS)
 async def ext_auth_service_logo() -> dict:
     """Unprotected route for the service logo."""
     return {}
 
 
-@app.api_route("/{path:path}", methods=HANDLE_METHODS)
+@app.api_route("/{path:path}", methods=ALL_METHODS)
 async def ext_auth(  # pylint:disable=too-many-arguments
     path: str,
     request: Request,

--- a/tests/integration/auth_adapter/test_api.py
+++ b/tests/integration/auth_adapter/test_api.py
@@ -139,7 +139,7 @@ def test_basic_auth(with_basic_auth, client):
 
 
 def test_basic_auth_well_known(with_basic_auth, client):
-    """Test that GET from well-known path is excluded from basic authentication."""
+    """Test that fetching from well-known path is excluded from basic authentication."""
 
     assert with_basic_auth
 
@@ -148,7 +148,20 @@ def test_basic_auth_well_known(with_basic_auth, client):
     assert response.status_code == status.HTTP_200_OK
     assert response.json() == {}
 
+    response = client.head("/.well-known/some/thing")
+
+    assert response.status_code == status.HTTP_200_OK
+
+    response = client.options("/.well-known/some/thing")
+
+    assert response.status_code == status.HTTP_200_OK
+
     response = client.post("/.well-known/some/thing")
+
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+    assert response.text == "GHGA Data Portal: Not authenticated"
+
+    response = client.delete("/.well-known/some/thing")
 
     assert response.status_code == status.HTTP_401_UNAUTHORIZED
     assert response.text == "GHGA Data Portal: Not authenticated"
@@ -157,6 +170,18 @@ def test_basic_auth_well_known(with_basic_auth, client):
 
     assert response.status_code == status.HTTP_401_UNAUTHORIZED
     assert response.text == "GHGA Data Portal: Not authenticated"
+
+
+def test_basic_auth_service_logo(with_basic_auth, client):
+    """Test that fetching the service logo is excluded from basic authentication."""
+
+    assert with_basic_auth
+
+    response = client.get("/service-logo.png")
+    assert response.status_code == status.HTTP_200_OK
+
+    response = client.head("/.well-known/some/thing")
+    assert response.status_code == status.HTTP_200_OK
 
 
 def test_does_not_authorize_invalid_users(client):


### PR DESCRIPTION
Some paths have been exempt from basic authentication, but only for the GET method. This PR extends this exemption to HEAD and OPTIONS requests to avoid errors e.g. with pre-flight requests.