### PR TITLE
Enable multi platform builds

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -4,6 +4,8 @@ on:
   release:
     types: [published]
       # trigger only on new release
+  push:
+    branches: [multi-platform-build]
 
 jobs:
   verify_version:
@@ -76,7 +78,7 @@ jobs:
         id: docker_build
         with:
           push: true
-          #       platforms: linux/amd64,linux/arm64/v8
+          platforms: linux/amd64,linux/arm64
           tags: "ghga/${{ github.event.repository.name }}:${{ needs.verify_version.outputs.version }}"
 
       - name: Run Trivy vulnerability scanner
@@ -94,27 +96,27 @@ jobs:
 
   # Please uncomment and adapt the DEPLOYMENT_CONFIG_REPO to trigger automatic
   # updates of helm charts:
-  update_deployment_repo:
-    runs-on: ubuntu-latest
-    needs:
-      - verify_version
-      - push_to_docker_hub
-    env:
-      DEPLOYMENT_CONFIG_REPO: ghga-de/helm
-    steps:
-      - name: trigger update in deployment repo
-        run: |
-          # access token needs to be of format: <username>:<personal_access_token>
-          curl -X POST \
-            "https://api.github.com/repos/${DEPLOYMENT_CONFIG_REPO}/dispatches" \
-            -H 'Accept: application/vnd.github.everest-preview+json' \
-            -u '${{ secrets.DEPLOYMENT_UPDATE_TOKEN }}' \
-            --data '{
-              "event_type": "new_app_version",
-              "client_payload": {
-                "deploy_filename": "${{ github.event.repository.name }}",
-                "app_name": "${{ github.event.repository.name }}",
-                "context": "${{ needs.verify_version.outputs.version }}",
-                "new_image_tag": "${{ needs.verify_version.outputs.version }}"
-              }
-            }'
+  # update_deployment_repo:
+  #   runs-on: ubuntu-latest
+  #   needs:
+  #     - verify_version
+  #     - push_to_docker_hub
+  #   env:
+  #     DEPLOYMENT_CONFIG_REPO: ghga-de/helm
+  #   steps:
+  #     - name: trigger update in deployment repo
+  #       run: |
+  #         # access token needs to be of format: <username>:<personal_access_token>
+  #         curl -X POST \
+  #           "https://api.github.com/repos/${DEPLOYMENT_CONFIG_REPO}/dispatches" \
+  #           -H 'Accept: application/vnd.github.everest-preview+json' \
+  #           -u '${{ secrets.DEPLOYMENT_UPDATE_TOKEN }}' \
+  #           --data '{
+  #             "event_type": "new_app_version",
+  #             "client_payload": {
+  #               "deploy_filename": "${{ github.event.repository.name }}",
+  #               "app_name": "${{ github.event.repository.name }}",
+  #               "context": "${{ needs.verify_version.outputs.version }}",
+  #               "new_image_tag": "${{ needs.verify_version.outputs.version }}"
+  #             }
+  #           }'

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -56,7 +56,7 @@ jobs:
 
   push_to_docker_hub:
     runs-on: ubuntu-latest
-    needs: verify_version
+    # needs: verify_version
     steps:
       - uses: actions/checkout@v3
         name: Check out code

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -8,51 +8,51 @@ on:
     branches: [multi-platform-build]
 
 jobs:
-  verify_version:
-    runs-on: ubuntu-latest
-    outputs:
-      # export to be used in other jobs
-      version: ${{ steps.get_version_tag.outputs.version }}
-    steps:
-      - uses: actions/checkout@v3
-        name: Check out code
+  # verify_version:
+  #   runs-on: ubuntu-latest
+  #   outputs:
+  #     # export to be used in other jobs
+  #     version: ${{ steps.get_version_tag.outputs.version }}
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #       name: Check out code
 
-      - uses: actions/setup-python@v4
-        name: Set up Python 3.9
-        with:
-          python-version: "3.9"
+  #     - uses: actions/setup-python@v4
+  #       name: Set up Python 3.9
+  #       with:
+  #         python-version: "3.9"
 
-      - id: get_version_tag
-        name: Get version tag
-        run: |
-          TAG_VER="${GITHUB_REF##*/}"
-          # set as output:
-          echo "version: ${TAG_VER}"
-          echo "version=${TAG_VER}" >> $GITHUB_OUTPUT
+  #     - id: get_version_tag
+  #       name: Get version tag
+  #       run: |
+  #         TAG_VER="${GITHUB_REF##*/}"
+  #         # set as output:
+  #         echo "version: ${TAG_VER}"
+  #         echo "version=${TAG_VER}" >> $GITHUB_OUTPUT
 
-      - id: verify_semantic_tag_format
-        name: Verify tag format
-        # format must be compatible with semantic versioning
-        run: |
-          SEMVER_REGEX="^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$"
-          if echo "${{ steps.get_version_tag.outputs.version }}" | grep -Eq "$SEMVER_REGEX"; then
-            echo "Tag format is valid"
-          else
-            echo "Invalid tag format: ${{ steps.get_version_tag.outputs.version }}"
-            exit 1
-          fi
+  #     - id: verify_semantic_tag_format
+  #       name: Verify tag format
+  #       # format must be compatible with semantic versioning
+  #       run: |
+  #         SEMVER_REGEX="^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$"
+  #         if echo "${{ steps.get_version_tag.outputs.version }}" | grep -Eq "$SEMVER_REGEX"; then
+  #           echo "Tag format is valid"
+  #         else
+  #           echo "Invalid tag format: ${{ steps.get_version_tag.outputs.version }}"
+  #           exit 1
+  #         fi
 
-      - id: verify_package_version
-        name: Verify package version vs tag version
-        # package version must be same with tag version
-        run: |
-          PKG_VER="$(python setup.py --version)"
-          echo "Package version is $PKG_VER" >&2
-          echo "Tag version is ${{ steps.get_version_tag.outputs.version }}" >&2
-          if [ "$PKG_VER" != "${{ steps.get_version_tag.outputs.version }}" ]; then
-            echo "Package version and tag name mismatch." >&2
-            exit 1
-          fi
+  #     - id: verify_package_version
+  #       name: Verify package version vs tag version
+  #       # package version must be same with tag version
+  #       run: |
+  #         PKG_VER="$(python setup.py --version)"
+  #         echo "Package version is $PKG_VER" >&2
+  #         echo "Tag version is ${{ steps.get_version_tag.outputs.version }}" >&2
+  #         if [ "$PKG_VER" != "${{ steps.get_version_tag.outputs.version }}" ]; then
+  #           echo "Package version and tag name mismatch." >&2
+  #           exit 1
+  #         fi
 
   push_to_docker_hub:
     runs-on: ubuntu-latest

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -4,59 +4,57 @@ on:
   release:
     types: [published]
       # trigger only on new release
-  push:
-    branches: [multi-platform-build]
 
 jobs:
-  # verify_version:
-  #   runs-on: ubuntu-latest
-  #   outputs:
-  #     # export to be used in other jobs
-  #     version: ${{ steps.get_version_tag.outputs.version }}
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #       name: Check out code
+  verify_version:
+    runs-on: ubuntu-latest
+    outputs:
+      # export to be used in other jobs
+      version: ${{ steps.get_version_tag.outputs.version }}
+    steps:
+      - uses: actions/checkout@v3
+        name: Check out code
 
-  #     - uses: actions/setup-python@v4
-  #       name: Set up Python 3.9
-  #       with:
-  #         python-version: "3.9"
+      - uses: actions/setup-python@v4
+        name: Set up Python 3.9
+        with:
+          python-version: "3.9"
 
-  #     - id: get_version_tag
-  #       name: Get version tag
-  #       run: |
-  #         TAG_VER="${GITHUB_REF##*/}"
-  #         # set as output:
-  #         echo "version: ${TAG_VER}"
-  #         echo "version=${TAG_VER}" >> $GITHUB_OUTPUT
+      - id: get_version_tag
+        name: Get version tag
+        run: |
+          TAG_VER="${GITHUB_REF##*/}"
+          # set as output:
+          echo "version: ${TAG_VER}"
+          echo "version=${TAG_VER}" >> $GITHUB_OUTPUT
 
-  #     - id: verify_semantic_tag_format
-  #       name: Verify tag format
-  #       # format must be compatible with semantic versioning
-  #       run: |
-  #         SEMVER_REGEX="^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$"
-  #         if echo "${{ steps.get_version_tag.outputs.version }}" | grep -Eq "$SEMVER_REGEX"; then
-  #           echo "Tag format is valid"
-  #         else
-  #           echo "Invalid tag format: ${{ steps.get_version_tag.outputs.version }}"
-  #           exit 1
-  #         fi
+      - id: verify_semantic_tag_format
+        name: Verify tag format
+        # format must be compatible with semantic versioning
+        run: |
+          SEMVER_REGEX="^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$"
+          if echo "${{ steps.get_version_tag.outputs.version }}" | grep -Eq "$SEMVER_REGEX"; then
+            echo "Tag format is valid"
+          else
+            echo "Invalid tag format: ${{ steps.get_version_tag.outputs.version }}"
+            exit 1
+          fi
 
-  #     - id: verify_package_version
-  #       name: Verify package version vs tag version
-  #       # package version must be same with tag version
-  #       run: |
-  #         PKG_VER="$(python setup.py --version)"
-  #         echo "Package version is $PKG_VER" >&2
-  #         echo "Tag version is ${{ steps.get_version_tag.outputs.version }}" >&2
-  #         if [ "$PKG_VER" != "${{ steps.get_version_tag.outputs.version }}" ]; then
-  #           echo "Package version and tag name mismatch." >&2
-  #           exit 1
-  #         fi
+      - id: verify_package_version
+        name: Verify package version vs tag version
+        # package version must be same with tag version
+        run: |
+          PKG_VER="$(python setup.py --version)"
+          echo "Package version is $PKG_VER" >&2
+          echo "Tag version is ${{ steps.get_version_tag.outputs.version }}" >&2
+          if [ "$PKG_VER" != "${{ steps.get_version_tag.outputs.version }}" ]; then
+            echo "Package version and tag name mismatch." >&2
+            exit 1
+          fi
 
   push_to_docker_hub:
     runs-on: ubuntu-latest
-    # needs: verify_version
+    needs: verify_version
     steps:
       - uses: actions/checkout@v3
         name: Check out code

--- a/auth_service/__init__.py
+++ b/auth_service/__init__.py
@@ -19,4 +19,4 @@ The GHGA auth service contains all services needed for the management,
 authentication and authorization of users.
 """
 
-__version__ = "0.3.1"
+__version__ = "0.3.2-alpha.1"


### PR DESCRIPTION
Currently the GHGA services are only built for x86_64/amd64 architectures. Not only does this limit the adoptability on more cost-efficient arm nodes, but also poses a problem for developers operating on arm cpus (such as newer MacBooks).

This can be fixed by adding the option platforms: linux/amd64,linux/arm64 to the docer/build-push-action.