### PR TITLE
Check for download access should return bool instead of str

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,13 +30,13 @@ We recommend using the provided Docker container.
 
 A pre-build version is available at [docker hub](https://hub.docker.com/repository/docker/ghga/auth-service):
 ```bash
-docker pull ghga/auth-service:0.5.0
+docker pull ghga/auth-service:0.5.1
 ```
 
 Or you can build the container yourself from the [`./Dockerfile`](./Dockerfile):
 ```bash
 # Execute in the repo's root dir:
-docker build -t ghga/auth-service:0.5.0 .
+docker build -t ghga/auth-service:0.5.1 .
 ```
 
 For production-ready deployment, we recommend using Kubernetes, however,
@@ -44,7 +44,7 @@ for simple use cases, you could execute the service using docker
 on a single server:
 ```bash
 # The entrypoint is preconfigured:
-docker run -p 8080:8080 ghga/auth-service:0.5.0 --help
+docker run -p 8080:8080 ghga/auth-service:0.5.1 --help
 ```
 
 If you prefer not to use containers, you may install the service from source:

--- a/auth_service/__init__.py
+++ b/auth_service/__init__.py
@@ -19,4 +19,4 @@ The GHGA auth service contains all services needed for the management,
 authentication and authorization of users.
 """
 
-__version__ = "0.5.0"
+__version__ = "0.5.1"

--- a/auth_service/user_management/claims_repository/router.py
+++ b/auth_service/user_management/claims_repository/router.py
@@ -42,18 +42,11 @@ from .models.dto import (
     VisaType,
 )
 
-try:  # workaround for https://github.com/pydantic/pydantic/issues/5821
-    from typing_extensions import Literal
-except ImportError:
-    from typing import Literal  # type: ignore
-
 __all__ = ["router"]
 
 log = logging.getLogger(__name__)
 
 router = APIRouter()
-
-BooleanAsString = Literal["false", "true"]
 
 
 user_not_found_error = HTTPException(status_code=404, detail="The user was not found.")
@@ -311,7 +304,7 @@ async def check_download_access(
     user_dao: UserDao = Depends(get_user_dao),
     claim_dao: ClaimDao = Depends(get_claim_dao),
     # internal service, authorization without token via service mesh
-) -> BooleanAsString:
+) -> bool:
     """Check download access permission for a given dataset by a given user"""
     if not await user_exists(user_id, user_dao):
         raise user_not_found_error
@@ -325,9 +318,9 @@ async def check_download_access(
     ):
         # check whether the claim is valid and for the right source
         if is_valid_claim(claim) and has_download_access_for_dataset(claim, dataset_id):
-            return "true"
+            return True
 
-    return "false"
+    return False
 
 
 @router.get(

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -6,7 +6,7 @@ info:
   license:
     name: Apache 2.0
   title: User Management API
-  version: 0.5.0
+  version: 0.5.1
 openapi: 3.0.2
 paths:
   /health:

--- a/tests/integration/user_management/claims_repository/test_api.py
+++ b/tests/integration/user_management/claims_repository/test_api.py
@@ -381,7 +381,7 @@ def test_check_download_access(client_with_db):
         "/download-access/users/john@ghga.de/datasets/some-dataset-id"
     )
     assert response.status_code == status.HTTP_200_OK
-    assert response.json() == "true"
+    assert response.json() is True
 
     # check access when permission exists but is not valid any more
 
@@ -389,7 +389,7 @@ def test_check_download_access(client_with_db):
         "/download-access/users/john@ghga.de/datasets/former-dataset-id"
     )
     assert response.status_code == status.HTTP_200_OK
-    assert response.json() == "false"
+    assert response.json() is False
 
     # check access when dataset and permission does not exist
 
@@ -397,7 +397,7 @@ def test_check_download_access(client_with_db):
         "/download-access/users/john@ghga.de/datasets/another-dataset-id"
     )
     assert response.status_code == status.HTTP_200_OK
-    assert response.json() == "false"
+    assert response.json() is False
 
 
 def test_get_datasets_with_download_access(client_with_db):


### PR DESCRIPTION
The REST API returned a literal string "true", which was padded with quotes since it was interpreted as JSON. However, the WPS expected a bool scalar value as JSON (without quotes). Fixed this to return what is expected by the WPS.

This is the kind of problem that can be detected with contract testing.