### PR TITLE
Separate the internal and external user ID in the session (GSI-663)

### DIFF
--- a/src/auth_service/auth_adapter/api/headers.py
+++ b/src/auth_service/auth_adapter/api/headers.py
@@ -42,12 +42,14 @@ def session_to_header(
 ) -> str:
     """Serialize a session to a response header value to be used by the frontend."""
     session_dict: dict[str, Union[str, int]] = {
-        "userId": session.user_id,
+        "ext_id": session.ext_id,
         "name": session.user_name,
         "email": session.user_email,
         "state": session.state.value,
         "csrf": session.csrf_token,
     }
+    if session.user_id:
+        session_dict["id"] = session.user_id
     if session.user_title:
         session_dict["title"] = session.user_title
     if timeouts:

--- a/src/auth_service/auth_adapter/core/session_store.py
+++ b/src/auth_service/auth_adapter/core/session_store.py
@@ -52,23 +52,23 @@ class Session(BaseSession):
         default=None,
         description="Internal ID of the associated user, if registered",
     )
-    user_name: str = Field(default=..., description="the full name of the user")
+    user_name: str = Field(default=..., description="The full name of the user")
     user_email: EmailStr = Field(
-        default=..., description="the email address of the user"
+        default=..., description="The email address of the user"
     )
     user_title: Optional[str] = Field(
-        default=None, description="optional academic title of the user"
+        default=None, description="Optional academic title of the user"
     )
     state: SessionState = Field(
         default=SessionState.NEEDS_REGISTRATION,
-        description="the authentication state of the user session",
+        description="The authentication state of the user session",
     )
-    csrf_token: str = Field(default=..., description="the CSRF token for the session")
+    csrf_token: str = Field(default=..., description="The CSRF token for the session")
     totp_token: Optional[TOTPToken] = Field(
-        default=None, description="the TOTP token of the user if available"
+        default=None, description="The TOTP token of the user if available"
     )
-    created: UTCDatetime = Field(description="time when the session was created")
-    last_used: UTCDatetime = Field(description="time when the session was last used")
+    created: UTCDatetime = Field(description="Time when the session was created")
+    last_used: UTCDatetime = Field(description="Time when the session was last used")
 
 
 class SessionConfig(BaseSettings):

--- a/src/auth_service/auth_adapter/core/session_store.py
+++ b/src/auth_service/auth_adapter/core/session_store.py
@@ -50,7 +50,7 @@ class Session(BaseSession):
     )
     user_id: Optional[str] = Field(
         default=None,
-        description="internal ID of the associated user, if registered",
+        description="Internal ID of the associated user, if registered",
     )
     user_name: str = Field(default=..., description="the full name of the user")
     user_email: EmailStr = Field(

--- a/tests/integration/auth_adapter/fixtures.py
+++ b/tests/integration/auth_adapter/fixtures.py
@@ -93,9 +93,11 @@ class ClientWithSession(NamedTuple):
 
 
 _map_session_dict_to_object = {
-    "userId": "user_id",
+    "ext_id": "ext_id",
+    "id": "user_id",
     "name": "user_name",
     "email": "user_email",
+    "title": "user_title",
     "csrf": "csrf_token",
 }
 

--- a/tests/integration/auth_adapter/test_sessions.py
+++ b/tests/integration/auth_adapter/test_sessions.py
@@ -78,7 +78,7 @@ async def test_logout(client: AsyncTestClient):
     """Test that a logout request removes the user session."""
     store = await get_session_store(config=CONFIG)
     session = await store.create_session(
-        user_id="john@ghga.de", user_name="John Doe", user_email="john@home.org"
+        ext_id="john@aai.org", user_name="John Doe", user_email="john@home.org"
     )
     assert await store.get_session(session.session_id)
     headers = headers_for_session(session)
@@ -105,7 +105,7 @@ async def test_logout_with_invalid_csrf_token(client: AsyncTestClient):
     """Test that a logout request with an invalid CSRF token fails."""
     store = await get_session_store(config=CONFIG)
     session = await store.create_session(
-        user_id="john@ghga.de", user_name="John Doe", user_email="john@home.org"
+        ext_id="john@aai.org", user_name="John Doe", user_email="john@home.org"
     )
     original_session = session.model_copy()
     headers = headers_for_session(session)
@@ -143,7 +143,7 @@ async def test_login_with_unregistered_user(
     assert_session_header(
         response,
         {
-            "userId": "john@aai.org",
+            "ext_id": "john@aai.org",
             "name": "John Doe",
             "email": "john@home.org",
             "state": "NeedsRegistration",
@@ -194,7 +194,8 @@ async def test_login_with_registered_user(
     assert_session_header(
         response,
         {
-            "userId": "john@ghga.de",
+            "id": "john@ghga.de",
+            "ext_id": "john@aai.org",
             "name": "John Doe",
             "email": "john@home.org",
             "state": "Registered",
@@ -225,7 +226,8 @@ async def test_login_with_registered_user_and_name_change(
     assert_session_header(
         response,
         {
-            "userId": "john@ghga.de",
+            "id": "john@ghga.de",
+            "ext_id": "john@aai.org",
             "name": "John Doe Jr.",
             "email": "john@home.org",
             "state": "NeedsReRegistration",
@@ -255,7 +257,8 @@ async def test_login_with_registered_user_with_title(
     assert_session_header(
         response,
         {
-            "userId": "john@ghga.de",
+            "id": "john@ghga.de",
+            "ext_id": "john@aai.org",
             "name": "John Doe",
             "email": "john@home.org",
             "title": "Dr.",
@@ -296,7 +299,7 @@ async def test_login_with_cookie_and_unregistered_user(client: AsyncTestClient):
 
     store = await get_session_store(config=CONFIG)
     session = await store.create_session(
-        user_id="john@aai.org", user_name="John Doe", user_email="john@home.org"
+        ext_id="john@aai.org", user_name="John Doe", user_email="john@home.org"
     )
     assert await store.get_session(session.session_id)
     headers = headers_for_session(session)
@@ -307,7 +310,7 @@ async def test_login_with_cookie_and_unregistered_user(client: AsyncTestClient):
     assert_session_header(
         response,
         {
-            "userId": "john@aai.org",
+            "ext_id": "john@aai.org",
             "name": "John Doe",
             "email": "john@home.org",
             "state": "NeedsRegistration",
@@ -322,7 +325,10 @@ async def test_login_with_cookie_and_registered_user(client: AsyncTestClient):
 
     store = await get_session_store(config=CONFIG)
     session_dict = await store.create_session(
-        user_id="john@aai.org", user_name="John Doe", user_email="john@home.org"
+        ext_id="john@aai.org",
+        user_id="john@ghga.de",
+        user_name="John Doe",
+        user_email="john@home.org",
     )
     assert await store.get_session(session_dict.session_id)
     headers = headers_for_session(session_dict)
@@ -333,7 +339,8 @@ async def test_login_with_cookie_and_registered_user(client: AsyncTestClient):
     assert_session_header(
         response,
         {
-            "userId": "john@ghga.de",
+            "id": "john@ghga.de",
+            "ext_id": "john@aai.org",
             "name": "John Doe",
             "email": "john@home.org",
             "state": "Registered",
@@ -346,7 +353,7 @@ async def test_login_with_cookie_and_invalid_csrf_token(client: AsyncTestClient)
     """Test login request with session cookie and invalid CSRF token."""
     store = await get_session_store(config=CONFIG)
     session = await store.create_session(
-        user_id="john@ghga.de", user_name="John Doe", user_email="john@home.org"
+        ext_id="john@aai.org", user_name="John Doe", user_email="john@home.org"
     )
     original_session = session.model_copy()
     assert await store.get_session(session.session_id)

--- a/tests/unit/auth_adapter/test_csrf.py
+++ b/tests/unit/auth_adapter/test_csrf.py
@@ -28,10 +28,10 @@ EXPECTED_ERROR_MESSAGE = "Invalid or missing CSRF token"
 
 SESSION = Session(
     session_id="some-session-id",
-    csrf_token="some-csrf-token",
-    user_id="some-user-id",
+    ext_id="john@aai.org",
     user_name="John Doe",
     user_email="john@home.org",
+    csrf_token="some-csrf-token",
     created=NOW,
     last_used=NOW,
 )

--- a/tests/unit/auth_adapter/test_headers.py
+++ b/tests/unit/auth_adapter/test_headers.py
@@ -57,6 +57,7 @@ def test_session_to_header_ascii():
     """Test that a session with ascii values is properly converted to a header."""
     session = Session(
         session_id="some-session-id",
+        ext_id="john@aai.org",
         user_id="some-user-id",
         user_name="John Doe",
         user_email="john@home.org",
@@ -65,8 +66,8 @@ def test_session_to_header_ascii():
         last_used=NOW,
     )
     assert session_to_header(session) == (
-        '{"userId":"some-user-id","name":"John Doe","email":"john@home.org",'
-        '"state":"NeedsRegistration","csrf":"some-csrf-token"}'
+        '{"ext_id":"john@aai.org","name":"John Doe","email":"john@home.org",'
+        '"state":"NeedsRegistration","csrf":"some-csrf-token","id":"some-user-id"}'
     )
 
 
@@ -74,6 +75,7 @@ def test_session_to_header_non_ascii():
     """Test that a session with non-ascii values is properly converted to a header."""
     session = Session(
         session_id="a-session-id",
+        ext_id="john@aai.org",
         user_id="a-user-id",
         user_name="Svante Pääbo",
         user_email="svante@home.se",
@@ -82,8 +84,25 @@ def test_session_to_header_non_ascii():
         last_used=NOW,
     )
     assert session_to_header(session) == (
-        '{"userId":"a-user-id","name":"Svante Pääbo","email":"svante@home.se",'
-        '"state":"NeedsRegistration","csrf":"a-csrf-token"}'
+        '{"ext_id":"john@aai.org","name":"Svante Pääbo","email":"svante@home.se",'
+        '"state":"NeedsRegistration","csrf":"a-csrf-token","id":"a-user-id"}'
+    )
+
+
+def test_session_to_header_without_optional_properties():
+    """Test that optional properties are omitted when converted."""
+    session = Session(
+        session_id="some-session-id",
+        ext_id="john@aai.org",
+        user_name="John Doe",
+        user_email="john@home.org",
+        csrf_token="some-csrf-token",
+        created=NOW,
+        last_used=NOW,
+    )
+    assert session_to_header(session) == (
+        '{"ext_id":"john@aai.org","name":"John Doe","email":"john@home.org",'
+        '"state":"NeedsRegistration","csrf":"some-csrf-token"}'
     )
 
 
@@ -91,6 +110,7 @@ def test_session_to_header_with_optional_properties():
     """Test that the optional properties of a session can also be converted."""
     session = Session(
         session_id="some-session-id",
+        ext_id="john@aai.org",
         user_id="some-user-id",
         user_name="John Doe",
         user_email="john@home.org",
@@ -100,7 +120,7 @@ def test_session_to_header_with_optional_properties():
         last_used=NOW,
     )
     assert session_to_header(session, lambda _session: (42, 144)) == (
-        '{"userId":"some-user-id","name":"John Doe","email":"john@home.org",'
+        '{"ext_id":"john@aai.org","name":"John Doe","email":"john@home.org",'
         '"state":"NeedsRegistration","csrf":"some-csrf-token",'
-        '"title":"Dr.","timeout":42,"extends":144}'
+        '"id":"some-user-id","title":"Dr.","timeout":42,"extends":144}'
     )

--- a/tests/unit/auth_adapter/test_memory_session_store.py
+++ b/tests/unit/auth_adapter/test_memory_session_store.py
@@ -25,10 +25,10 @@ from auth_service.auth_adapter.adapters.memory_session_store import MemorySessio
 from auth_service.auth_adapter.core.session_store import Session, SessionConfig
 
 USER_KWARGS = dict(
-    user_id="some-user-id", user_name="John Doe", user_email="john@home.org"
+    ext_id="john@aai.org", user_name="John Doe", user_email="john@home.org"
 )
 USER2_KWARGS = dict(
-    user_id="another-user-id", user_name="Jane Roe", user_email="jane@home.org"
+    ext_id="jane@aai.org", user_name="Jane Roe", user_email="jane@home.org"
 )
 
 
@@ -108,9 +108,10 @@ async def test_save_session(store):
     """Test saving a session."""
     session = store._create_session(**USER_KWARGS)
     await store.save_session(session)
-    assert session.user_id == USER_KWARGS["user_id"]
+    assert session.ext_id == USER_KWARGS["ext_id"]
     assert session.user_name == USER_KWARGS["user_name"]
     assert session.user_email == USER_KWARGS["user_email"]
+    assert session.user_id is None
     assert session.created == store.now
     assert session.last_used == store.now
     assert await store.get_size() == 1
@@ -123,12 +124,12 @@ async def test_update_session(store):
     session = await store.create_session(**USER_KWARGS)
     assert await store.get_size() == 1
     assert await store.get_session(session.session_id) is session
-    assert session.user_id == "some-user-id"
-    session = session.model_copy(update={"user_id": "another-user-id"})
+    assert session.ext_id == "john@aai.org"
+    session = session.model_copy(update={"user_email": "john@elsewhere.org"})
     await store.save_session(session)
     assert await store.get_size() == 1
     assert await store.get_session(session.session_id) is session
-    assert session.user_id == "another-user-id"
+    assert session.user_email == "john@elsewhere.org"
 
 
 @mark.asyncio
@@ -195,7 +196,7 @@ async def test_get_size(store):
     assert await store.get_size() == 0
     for i in range(10):
         await store.create_session(
-            user_id="some-user-id", user_name="John Doe", user_email="john@home.org"
+            ext_id="john@aai.org", user_name="John Doe", user_email="john@home.org"
         )
         assert await store.get_size() == i + 1
 
@@ -205,7 +206,7 @@ async def test_session_sweeper(store):
     """Test sweeping the session store."""
     sessions = [
         await store.create_session(
-            user_id="some-user-id", user_name="John Doe", user_email="john@home.org"
+            ext_id="john@aai.org", user_name="John Doe", user_email="john@home.org"
         )
         for _ in range(10)
     ]


### PR DESCRIPTION
So far, the Session objects contained a single field for storing the user ID, which was the internal user ID if the user was already registered, and the external user ID otherwise.

To avoid this dual use of the same field and to support showing the external ID on the profile page for an already registered user, the session now has two fields, corresponding to the same fields in the User model.