### PR TITLE
Special handling for users endpoint in auth adapter (GSI-645)

### DIFF
--- a/src/auth_service/auth_adapter/api/headers.py
+++ b/src/auth_service/auth_adapter/api/headers.py
@@ -52,6 +52,8 @@ def session_to_header(
         session_dict["id"] = session.user_id
     if session.user_title:
         session_dict["title"] = session.user_title
+    if session.role:
+        session_dict["role"] = session.role
     if timeouts:
         timeout_soft, timeout_hard = timeouts(session)
         session_dict["timeout"] = timeout_soft

--- a/src/auth_service/auth_adapter/api/main.py
+++ b/src/auth_service/auth_adapter/api/main.py
@@ -36,7 +36,7 @@ from auth_service.user_management.user_registry.deps import (
     UserDao,
     get_user_dao,
 )
-from auth_service.user_management.user_registry.models.dto import User
+from auth_service.user_management.user_registry.models.dto import User, UserStatus
 
 from .. import DESCRIPTION, TITLE, VERSION
 from ..core.auth import (
@@ -145,6 +145,12 @@ async def login(  # noqa: PLR0913
             user = await user_dao.find_one(mapping={"ext_id": session.ext_id})
         except NoHitsFoundError:
             user = None  # user is not yet registered
+
+    if user and user.status is not UserStatus.ACTIVE:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="User account is disabled",
+        )
 
     async def has_totp_token(user: User) -> bool:
         try:

--- a/src/auth_service/auth_adapter/core/session_store.py
+++ b/src/auth_service/auth_adapter/core/session_store.py
@@ -59,6 +59,7 @@ class Session(BaseSession):
     user_title: Optional[str] = Field(
         default=None, description="Optional academic title of the user"
     )
+    role: Optional[str] = Field(default=None, description="Optional role of the user")
     state: SessionState = Field(
         default=SessionState.NEEDS_REGISTRATION,
         description="The authentication state of the user session",
@@ -137,6 +138,7 @@ class SessionStore(SessionStorePort[Session]):
         user_email: str,
         user_id: Optional[str] = None,
         user_title: Optional[str] = None,
+        role: Optional[str] = None,
     ) -> Session:
         """Create a new user session without saving it."""
         session_id = self._generate_session_id()
@@ -149,6 +151,7 @@ class SessionStore(SessionStorePort[Session]):
             user_name=user_name,
             user_email=user_email,
             user_title=user_title,
+            role=role,
             csrf_token=csrf_token,
             created=created,
             last_used=created,

--- a/src/auth_service/auth_adapter/core/session_store.py
+++ b/src/auth_service/auth_adapter/core/session_store.py
@@ -181,6 +181,7 @@ class SessionStore(SessionStorePort[Session]):
         self,
         session: Session,
         user: Optional[User] = None,
+        is_data_steward: Optional[AsyncUserPredicate] = None,
         has_totp_token: Optional[AsyncUserPredicate] = None,
     ) -> None:
         """Update the given user session."""
@@ -196,6 +197,8 @@ class SessionStore(SessionStorePort[Session]):
                 session.user_email = user.email
                 session.user_title = user.title
                 session.state = SessionState.REGISTERED
+                if is_data_steward and await is_data_steward(user):
+                    session.role = "data_steward"
             if (
                 session.state is SessionState.REGISTERED
                 and has_totp_token

--- a/src/auth_service/user_management/claims_repository/router.py
+++ b/src/auth_service/user_management/claims_repository/router.py
@@ -85,7 +85,7 @@ async def post_claim(
     claim_dao: Annotated[ClaimDao, Depends(get_claim_dao)],
 ) -> Claim:
     """Store a user claim"""
-    if not await user_exists(user_id, user_dao):
+    if not await user_exists(user_id, user_dao=user_dao):
         raise user_not_found_error
 
     current_date = now_as_utc()
@@ -133,7 +133,7 @@ async def get_claims(
     claim_dao: Annotated[ClaimDao, Depends(get_claim_dao)],
 ) -> list[Claim]:
     """Get all claims for a given user"""
-    if not await user_exists(user_id, user_dao):
+    if not await user_exists(user_id, user_dao=user_dao):
         raise user_not_found_error
 
     return [claim async for claim in claim_dao.find_all(mapping={"user_id": user_id})]
@@ -174,7 +174,7 @@ async def patch_user(
     claim_dao: Annotated[ClaimDao, Depends(get_claim_dao)],
 ) -> Response:
     """Revoke an existing user claim"""
-    if not await user_exists(user_id, user_dao):
+    if not await user_exists(user_id, user_dao=user_dao):
         raise user_not_found_error
 
     try:
@@ -232,7 +232,7 @@ async def delete_claim(
     claim_dao: Annotated[ClaimDao, Depends(get_claim_dao)],
 ) -> Response:
     """Delete an existing user claim"""
-    if not await user_exists(user_id, user_dao):
+    if not await user_exists(user_id, user_dao=user_dao):
         raise user_not_found_error
 
     try:
@@ -289,7 +289,7 @@ async def grant_download_access(
     # internal service, authorization without token via service mesh
 ) -> Response:
     """Grant download access permission for a given dataset to a given user."""
-    if not await user_exists(user_id, user_dao):
+    if not await user_exists(user_id, user_dao=user_dao):
         raise user_not_found_error
 
     claim = create_controlled_access_claim(
@@ -336,7 +336,7 @@ async def check_download_access(
     # internal service, authorization without token via service mesh
 ) -> bool:
     """Check download access permission for a given dataset by a given user"""
-    if not await user_exists(user_id, user_dao):
+    if not await user_exists(user_id, user_dao=user_dao):
         raise user_not_found_error
 
     # run through all controlled access grants for the user
@@ -383,7 +383,7 @@ async def get_datasets_with_download_access(
     # internal service, authorization without token via service mesh
 ) -> list[str]:
     """Get list of all dataset IDs with download access permission for a given user"""
-    if not await user_exists(user_id, user_dao):
+    if not await user_exists(user_id, user_dao=user_dao):
         raise user_not_found_error
 
     # fetch all valid controlled access grants for the user

--- a/src/auth_service/user_management/user_registry/router.py
+++ b/src/auth_service/user_management/user_registry/router.py
@@ -77,7 +77,7 @@ async def post_user(
     user_dao: Annotated[UserDao, Depends(get_user_dao)],
     auth_context: Annotated[AuthContext, require_auth],
 ) -> User:
-    """Register a user"""
+    """Register a user."""
     ext_id = user_data.ext_id
     # users can only register themselves
     if ext_id != auth_context.ext_id:
@@ -138,7 +138,7 @@ async def put_user(
     user_dao: Annotated[UserDao, Depends(get_user_dao)],
     auth_context: Annotated[AuthContext, require_auth],
 ) -> Response:
-    """Update a user"""
+    """Update a user."""
     # users can only update themselves,
     # invalid users are allowed to update themselves in order to become valid again
     if not (
@@ -193,7 +193,7 @@ async def get_user(
     user_dao: Annotated[UserDao, Depends(get_user_dao)],
     auth_context: Annotated[AuthContext, require_auth],
 ) -> User:
-    """Get user data"""
+    """Get user data."""
     # Only data steward can request other user accounts
     if not (
         is_steward(auth_context)
@@ -251,7 +251,7 @@ async def patch_user(
     user_dao: Annotated[UserDao, Depends(get_user_dao)],
     auth_context: Annotated[AuthContext, require_active],
 ) -> Response:
-    """Modify user data"""
+    """Modify user data."""
     update_data = user_data.model_dump(exclude_unset=True)
     # Everybody is allowed to modify their own data except the status,
     # but only data stewards are allowed to modify other accounts
@@ -317,7 +317,7 @@ async def delete_user(
     user_dao: Annotated[UserDao, Depends(get_user_dao)],
     auth_context: Annotated[AuthContext, require_steward],
 ) -> Response:
-    """Delete user"""
+    """Delete user."""
     if id_ == auth_context.id:
         raise HTTPException(
             status_code=403, detail="Not authorized to delete this user."

--- a/tests/integration/auth_adapter/fixtures.py
+++ b/tests/integration/auth_adapter/fixtures.py
@@ -37,11 +37,13 @@ from auth_service.auth_adapter.core.totp import TOTPHandler
 from auth_service.auth_adapter.deps import get_user_token_dao
 from auth_service.auth_adapter.ports.dao import UserToken
 from auth_service.deps import Config, get_config
+from auth_service.user_management.claims_repository.deps import get_claim_dao
 from auth_service.user_management.user_registry.deps import get_user_dao
 
 from ...fixtures.utils import (
     RE_USER_INFO_URL,
     USER_INFO,
+    DummyClaimDao,
     DummyUserDao,
     create_access_token,
     headers_for_session,
@@ -170,6 +172,8 @@ async def fixture_client_with_session(
     main.app.dependency_overrides[get_user_dao] = lambda: user_dao
     user_token_dao = DummyUserTokenDao()
     main.app.dependency_overrides[get_user_token_dao] = lambda: user_token_dao
+    claim_dao = DummyClaimDao()
+    main.app.dependency_overrides[get_claim_dao] = lambda: claim_dao
 
     session = await query_new_session(client)
     yield ClientWithSession(client, session, user_token_dao)

--- a/tests/integration/auth_adapter/test_api.py
+++ b/tests/integration/auth_adapter/test_api.py
@@ -734,6 +734,8 @@ async def test_put_registered_user_with_session(
     main.app.dependency_overrides[get_user_dao] = lambda: user_dao
     user_token_dao = DummyUserTokenDao()
     main.app.dependency_overrides[get_user_token_dao] = lambda: user_token_dao
+    claim_dao = DummyClaimDao()
+    main.app.dependency_overrides[get_claim_dao] = lambda: claim_dao
 
     session = await query_new_session(client)
     assert session.user_id == "john@ghga.de"

--- a/tests/integration/auth_adapter/test_api.py
+++ b/tests/integration/auth_adapter/test_api.py
@@ -27,6 +27,7 @@ from pytest_httpx import HTTPXMock
 
 from auth_service.auth_adapter.api import main
 from auth_service.auth_adapter.api.headers import get_bearer_token
+from auth_service.auth_adapter.deps import get_user_token_dao
 from auth_service.config import CONFIG
 from auth_service.user_management.claims_repository.deps import ClaimDao, get_claim_dao
 from auth_service.user_management.user_registry.deps import UserDao, get_user_dao
@@ -41,6 +42,7 @@ from ...fixtures.utils import (
 )
 from .fixtures import (  # noqa: F401
     ClientWithSession,
+    DummyUserTokenDao,
     fixture_client,
     fixture_client_with_session,
     fixture_with_basic_auth,
@@ -626,10 +628,11 @@ async def test_post_user_with_session(client: AsyncTestClient, httpx_mock: HTTPX
     """Test user registration with session and valid CSRF token."""
     httpx_mock.add_response(url=RE_USER_INFO_URL, json=USER_INFO)
 
-    user_dao = DummyUserDao(ext_id="not.john@ghga.de")
+    user_dao = DummyUserDao(ext_id="not.john@aai.org")
     main.app.dependency_overrides[get_user_dao] = lambda: user_dao
 
     session = await query_new_session(client)
+    assert not session.user_id
 
     response = await client.post("/users", headers=headers_for_session(session))
 
@@ -647,6 +650,112 @@ async def test_post_user_with_session(client: AsyncTestClient, httpx_mock: HTTPX
 
     assert set(claims) == expected_claims
     assert claims["id"] == "john@aai.org"
+    assert claims["name"] == "John Doe"
+    assert claims["email"] == "john@home.org"
+    assert claims["title"] is None
+    assert claims["role"] is None
+
+    iat = claims["iat"]
+    assert isinstance(iat, int)
+    assert 0 <= now_as_utc().timestamp() - iat < 5
+    exp = claims["exp"]
+    assert isinstance(exp, int)
+    assert 0 <= exp - iat - 3600 < 2
+
+
+@mark.asyncio
+async def test_put_user_without_session(client: AsyncTestClient):
+    """Test authentication for user update without a session."""
+    response = await client.put("/users/some-internal-id")
+
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+    assert response.json() == {"detail": "Not logged in"}
+
+
+@mark.asyncio
+async def test_put_user_with_session_and_wrong_user_id(
+    client_with_session: ClientWithSession,
+):
+    """Test user update with session and wrong user ID."""
+    client, session = client_with_session[:2]
+    response = await client.put(
+        "/users/jane@ghga.de", headers=headers_for_session(session)
+    )
+
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+    assert response.json() == {"detail": "Not registered"}
+
+
+@mark.asyncio
+async def test_put_user_with_session_and_invalid_csrf(
+    client_with_session: ClientWithSession,
+):
+    """Test user update with session and invalid CSRF token."""
+    client, session = client_with_session[:2]
+    session.csrf_token = "invalid"
+    response = await client.put(
+        "/users/john@ghga.de", headers=headers_for_session(session)
+    )
+
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+    assert response.json() == {"detail": "Invalid or missing CSRF token"}
+
+
+@mark.asyncio
+async def test_put_unregistered_user_with_session(
+    client: AsyncTestClient,
+    httpx_mock: HTTPXMock,
+):
+    """Test updating an unregistered user with session."""
+    httpx_mock.add_response(url=RE_USER_INFO_URL, json=USER_INFO)
+
+    user_dao = DummyUserDao(ext_id="not.john@aai.org")
+    main.app.dependency_overrides[get_user_dao] = lambda: user_dao
+
+    session = await query_new_session(client)
+    assert not session.user_id
+
+    response = await client.put(
+        "/users/john@ghga.de", headers=headers_for_session(session)
+    )
+
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+    assert response.json() == {"detail": "Not registered"}
+
+
+@mark.asyncio
+async def test_put_registered_user_with_session(
+    client: AsyncTestClient, httpx_mock: HTTPXMock
+):
+    """Test updating a registered user with session."""
+    httpx_mock.add_response(url=RE_USER_INFO_URL, json=USER_INFO)
+
+    user_dao = DummyUserDao()
+    main.app.dependency_overrides[get_user_dao] = lambda: user_dao
+    user_token_dao = DummyUserTokenDao()
+    main.app.dependency_overrides[get_user_token_dao] = lambda: user_token_dao
+
+    session = await query_new_session(client)
+    assert session.user_id == "john@ghga.de"
+
+    response = await client.put(
+        "/users/john@ghga.de", headers=headers_for_session(session)
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert not response.text
+    authorization = response.headers["Authorization"]
+    assert authorization
+
+    internal_token = get_bearer_token(authorization)
+    assert internal_token
+
+    claims = get_claims_from_token(internal_token)
+    assert isinstance(claims, dict)
+    expected_claims = {"id", "name", "email", "title", "exp", "iat", "role"}
+
+    assert set(claims) == expected_claims
+    assert claims["id"] == "john@ghga.de"
     assert claims["name"] == "John Doe"
     assert claims["email"] == "john@home.org"
     assert claims["title"] is None

--- a/tests/integration/user_management/claims_repository/test_api.py
+++ b/tests/integration/user_management/claims_repository/test_api.py
@@ -33,7 +33,7 @@ from .fixtures import (  # noqa: F401
 
 ROLE_CLAIM_DATA = {
     "visa_type": "https://www.ghga.de/GA4GH/VisaTypes/Role/v1.0",
-    "visa_value": "data-steward@ghga.de",
+    "visa_value": "data_steward@ghga.de",
     "valid_from": "2022-10-01T12:00:00Z",
     "valid_until": "2022-10-31T12:00:00Z",
     "assertion_date": "2022-09-01T12:00:00Z",

--- a/tests/integration/user_management/claims_repository/test_dao.py
+++ b/tests/integration/user_management/claims_repository/test_dao.py
@@ -46,7 +46,7 @@ async def test_claim_creation(
     claim_data = ClaimFullCreation(
         user_id="some-internal-user-id",
         visa_type=VisaType.GHGA_ROLE,
-        visa_value="data-steward@ghga.de",
+        visa_value="data_steward@ghga.de",
         assertion_date=utc_datetime(2022, 9, 1),
         valid_from=utc_datetime(2022, 10, 1),
         valid_until=utc_datetime(2022, 10, 31),

--- a/tests/unit/auth_adapter/test_headers.py
+++ b/tests/unit/auth_adapter/test_headers.py
@@ -115,6 +115,7 @@ def test_session_to_header_with_optional_properties():
         user_name="John Doe",
         user_email="john@home.org",
         user_title="Dr.",
+        role="data_steward@ghga.de",
         csrf_token="some-csrf-token",
         created=NOW,
         last_used=NOW,
@@ -122,5 +123,6 @@ def test_session_to_header_with_optional_properties():
     assert session_to_header(session, lambda _session: (42, 144)) == (
         '{"ext_id":"john@aai.org","name":"John Doe","email":"john@home.org",'
         '"state":"NeedsRegistration","csrf":"some-csrf-token",'
-        '"id":"some-user-id","title":"Dr.","timeout":42,"extends":144}'
+        '"id":"some-user-id","title":"Dr.","role":"data_steward@ghga.de",'
+        '"timeout":42,"extends":144}'
     )

--- a/tests/unit/user_management/claims_repository/test_utils.py
+++ b/tests/unit/user_management/claims_repository/test_utils.py
@@ -16,12 +16,16 @@
 
 """Unit tests for the utils module."""
 
+from typing import cast
+
 from pytest import mark
 
 from auth_service.user_management.claims_repository.core.utils import (
     is_data_steward,
     user_exists,
 )
+from auth_service.user_management.claims_repository.ports.dao import ClaimDao
+from auth_service.user_management.user_registry.ports.dao import UserDao
 
 from ....fixtures.utils import DummyClaimDao, DummyUserDao
 
@@ -29,22 +33,35 @@ from ....fixtures.utils import DummyClaimDao, DummyUserDao
 @mark.asyncio
 async def test_user_exists():
     """Test that existence of users can be checked."""
-    user_dao = DummyUserDao(id_="some-internal-id")
-    assert await user_exists(None, user_dao) is False  # type: ignore
-    assert await user_exists("some-internal-id", user_dao) is True
-    assert await user_exists("other-internal-id", user_dao) is False
+    user_dao = cast(UserDao, DummyUserDao(id_="some-internal-id"))
+    assert await user_exists(None, user_dao=user_dao) is False  # type: ignore
+    assert await user_exists("some-internal-id", user_dao=user_dao) is True
+    assert await user_exists("other-internal-id", user_dao=user_dao) is False
 
 
 @mark.asyncio
 async def test_is_data_steward():
     """Test check that a user is a data steward."""
     claim_dao = DummyClaimDao()
-    user_dao = DummyUserDao(id_="james@ghga.de")
-    assert await is_data_steward("james@ghga.de", user_dao, claim_dao)
-    assert not await is_data_steward("john@ghga.de", user_dao, claim_dao)
-    assert not await is_data_steward(
-        "james@ghga.de", user_dao, claim_dao, now=lambda: claim_dao.invalid_date
+    invalid_date = claim_dao.invalid_date
+    claim_dao = cast(ClaimDao, claim_dao)
+    user_dao = cast(UserDao, DummyUserDao(id_="james@ghga.de"))
+    assert await is_data_steward(
+        "james@ghga.de", user_dao=user_dao, claim_dao=claim_dao
     )
-    user_dao = DummyUserDao("jane@ghga.de")
-    assert not await is_data_steward("james@ghga.de", user_dao, claim_dao)
-    assert not await is_data_steward("john@ghga.de", user_dao, claim_dao)
+    assert not await is_data_steward(
+        "john@ghga.de", user_dao=user_dao, claim_dao=claim_dao
+    )
+    assert not await is_data_steward(
+        "james@ghga.de",
+        user_dao=user_dao,
+        claim_dao=claim_dao,
+        now=lambda: invalid_date,
+    )
+    user_dao = cast(UserDao, DummyUserDao("jane@ghga.de"))
+    assert not await is_data_steward(
+        "james@ghga.de", user_dao=user_dao, claim_dao=claim_dao
+    )
+    assert not await is_data_steward(
+        "john@ghga.de", user_dao=user_dao, claim_dao=claim_dao
+    )


### PR DESCRIPTION
This PR implements the two endpoints for creating and updating users in the auth adapter, since the need special treatment. In these cases, an internal auth token needs to be created even though the user is not yet fully authenticated.

The PR also adds the status and role fields to the user session.