### PR TITLE
Limit total number of failed 2FA logins (GSI-638)

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,9 @@ The service requires the following configuration parameters:
 
 - **`totp_tolerance`** *(integer)*: Number of intervals to check before and after the current time. Minimum: `0`. Maximum: `10`. Default: `1`.
 
-- **`totp_attempts`** *(integer)*: Maximum number of attempts to verify a TOTP code. Minimum: `1`. Maximum: `10`. Default: `3`.
+- **`totp_attempts_per_code`** *(integer)*: Maximum number of attempts to verify an individual TOTP code. Minimum: `1`. Maximum: `10`. Default: `3`.
+
+- **`totp_max_failed_attempts`** *(integer)*: Maximum number of consecutive failed attempts to verify TOTP codes. Minimum: `1`. Maximum: `100`. Default: `10`.
 
 - **`totp_secret_size`** *(integer)*: Size of the Base32 encoded TOTP secrets. Minimum: `24`. Maximum: `256`. Default: `32`.
 

--- a/config_schema.json
+++ b/config_schema.json
@@ -224,12 +224,20 @@
       "title": "Totp Tolerance",
       "type": "integer"
     },
-    "totp_attempts": {
+    "totp_attempts_per_code": {
       "default": 3,
-      "description": "Maximum number of attempts to verify a TOTP code",
+      "description": "Maximum number of attempts to verify an individual TOTP code",
       "maximum": 10,
       "minimum": 1,
-      "title": "Totp Attempts",
+      "title": "Totp Attempts Per Code",
+      "type": "integer"
+    },
+    "totp_max_failed_attempts": {
+      "default": 10,
+      "description": "Maximum number of consecutive failed attempts to verify TOTP codes",
+      "maximum": 100,
+      "minimum": 1,
+      "title": "Totp Max Failed Attempts",
       "type": "integer"
     },
     "totp_secret_size": {

--- a/example_config.yaml
+++ b/example_config.yaml
@@ -58,12 +58,13 @@ session_id_bytes: 24
 session_max_lifetime_seconds: 43200
 session_timeout_seconds: 3600
 totp_algorithm: sha1
-totp_attempts: 3
+totp_attempts_per_code: 3
 totp_digits: 6
 totp_encryption_key: null
 totp_image: null
 totp_interval: 30
 totp_issuer: GHGA
+totp_max_failed_attempts: 10
 totp_secret_size: 32
 totp_tolerance: 1
 user_tokens_collection: user_tokens

--- a/src/auth_service/auth_adapter/core/session_store.py
+++ b/src/auth_service/auth_adapter/core/session_store.py
@@ -162,9 +162,11 @@ class SessionStore(SessionStorePort[Session]):
         config = self.config
         now = self._now()
         return (
-            abs((now - session.created).total_seconds())
+            0
+            <= (now - session.created).total_seconds()
             < config.session_max_lifetime_seconds
-            and abs((now - session.last_used).total_seconds())
+            and 0
+            <= (now - session.last_used).total_seconds()
             < config.session_timeout_seconds
         )
 

--- a/src/auth_service/auth_adapter/core/session_store.py
+++ b/src/auth_service/auth_adapter/core/session_store.py
@@ -162,8 +162,10 @@ class SessionStore(SessionStorePort[Session]):
         config = self.config
         now = self._now()
         return (
-            0 <= (now - session.created).seconds < config.session_max_lifetime_seconds
-            and 0 <= (now - session.last_used).seconds < config.session_timeout_seconds
+            abs((now - session.created).total_seconds())
+            < config.session_max_lifetime_seconds
+            and abs((now - session.last_used).total_seconds())
+            < config.session_timeout_seconds
         )
 
     @staticmethod

--- a/src/auth_service/auth_adapter/core/verify_totp.py
+++ b/src/auth_service/auth_adapter/core/verify_totp.py
@@ -1,0 +1,112 @@
+# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Application logic for verifying user TOTP tokens."""
+
+from fastapi import HTTPException, status
+from ghga_service_commons.utils.utc_dates import now_as_utc
+from hexkit.protocols.dao import ResourceNotFoundError
+
+from auth_service.user_management.user_registry.models.dto import (
+    StatusChange,
+    UserStatus,
+)
+from auth_service.user_management.user_registry.ports.dao import UserDao
+
+from ..ports.dao import UserToken, UserTokenDao
+from ..ports.session_store import SessionStorePort
+from ..ports.totp import TOTPHandlerPort
+from .session_store import Session, SessionState
+
+__all__ = ["verify_totp"]
+
+
+async def verify_totp(  # noqa: C901, PLR0912, PLR0913
+    totp: str,
+    user_id: str,
+    *,
+    session_store: SessionStorePort,
+    session: Session,
+    totp_handler: TOTPHandlerPort,
+    user_dao: UserDao,
+    token_dao: UserTokenDao,
+) -> None:
+    """Verify the given TOTP code for the user with the given ID."""
+    if session.state == SessionState.NEW_TOTP_TOKEN:
+        # get not yet verified TOTP token from the session
+        user = user_token = None
+        totp_token = session.totp_token
+    else:
+        # get verified TOTP token from the database
+        try:
+            user = await user_dao.get_by_id(user_id)
+        except ResourceNotFoundError:
+            user = user_token = None
+        else:
+            try:
+                user_token = await token_dao.get_by_id(user.id)
+            except ResourceNotFoundError:
+                user_token = None
+        totp_token = user_token.totp_token if user_token else None
+    if totp_token and totp:
+        if totp_handler.is_invalid(totp_token):
+            limit = True
+            verified = None
+            # too many invalid TOTP codes
+            if user and user.status is UserStatus.ACTIVE:
+                # disable the user account
+                user = user.model_copy(
+                    update={
+                        "status": UserStatus.INACTIVE,
+                        "status_change": StatusChange(
+                            previous=user.status,
+                            by=session.user_id,
+                            context="Too many failed TOTP login attempts",
+                            change_date=now_as_utc(),
+                        ),
+                    }
+                )
+                await user_dao.update(user)
+            # reset the TOTP token again
+            totp_handler.reset(totp_token)
+            # remove the session (logging the user out)
+            await session_store.delete_session(session.session_id)
+        else:
+            limit = False
+            verified = totp_handler.verify_code(totp_token, totp)
+    else:
+        limit = False
+        verified = None
+    if not verified:
+        if verified is not None:
+            await session_store.save_session(session)
+            if user_token:
+                await token_dao.update(user_token)
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Too many failed attempts" if limit else "Invalid TOTP code",
+        )
+    if session.state == SessionState.NEW_TOTP_TOKEN and totp_token:
+        # TODO: this operation must also delete all IVAs of the user
+        # store token in the database
+        user_token = UserToken(
+            user_id=user_id,
+            totp_token=totp_token,
+        )
+        await token_dao.upsert(user_token)
+    session.totp_token = None  # remove verified TOTP token from the session
+    session.state = SessionState.AUTHENTICATED
+    await session_store.save_session(session)

--- a/src/auth_service/auth_adapter/ports/totp.py
+++ b/src/auth_service/auth_adapter/ports/totp.py
@@ -73,3 +73,12 @@ class TOTPHandlerPort(ABC, Generic[T]):
         been changed and the token should be saved back to the database.
         """
         ...
+
+    @abstractmethod
+    def is_invalid(self, token: T) -> bool:
+        """Check if a token has become invalid."""
+        ...
+
+    @abstractmethod
+    def reset(self, token: T) -> None:
+        """Reset a token that has become invalid."""

--- a/tests/fixtures/utils.py
+++ b/tests/fixtures/utils.py
@@ -30,6 +30,7 @@ from hexkit.protocols.dao import NoHitsFoundError, ResourceNotFoundError
 from jwcrypto import jwk, jwt
 
 from auth_service.auth_adapter.core.session_store import Session
+from auth_service.auth_adapter.ports.dao import UserToken
 from auth_service.config import CONFIG
 from auth_service.user_management.claims_repository.models.dto import (
     AuthorityLevel,
@@ -244,6 +245,29 @@ class DummyUserDao:
         """Update the dummy user."""
         if user.id == self.user.id:
             self.user = user
+
+
+class DummyUserTokenDao:
+    """Dummy UserTokenDao for testing."""
+
+    def __init__(self):
+        """Initialize the dummy UserTokenDao"""
+        self.user_tokens = {}
+
+    async def get_by_id(self, id_: str) -> UserToken:
+        """Get the user token via the ID."""
+        try:
+            return self.user_tokens[id_]
+        except KeyError as error:
+            raise ResourceNotFoundError(id_=id_) from error
+
+    async def update(self, dto: UserToken) -> None:
+        """Update a user token."""
+        self.user_tokens[dto.user_id] = dto
+
+    async def upsert(self, dto: UserToken) -> None:
+        """Upsert a user token."""
+        self.user_tokens[dto.user_id] = dto
 
 
 class DummyClaimDao:

--- a/tests/integration/auth_adapter/test_api.py
+++ b/tests/integration/auth_adapter/test_api.py
@@ -36,12 +36,12 @@ from auth_service.user_management.user_registry.deps import get_user_dao
 from ...fixtures.utils import (
     DummyClaimDao,
     DummyUserDao,
+    DummyUserTokenDao,
     get_claims_from_token,
     headers_for_session,
 )
 from .fixtures import (  # noqa: F401
     ClientWithSession,
-    DummyUserTokenDao,
     fixture_client,
     fixture_client_with_session,
     fixture_with_basic_auth,

--- a/tests/integration/auth_adapter/test_sessions.py
+++ b/tests/integration/auth_adapter/test_sessions.py
@@ -37,10 +37,11 @@ from ...fixtures.utils import (
     USER_INFO,
     DummyClaimDao,
     DummyUserDao,
+    DummyUserTokenDao,
     create_access_token,
     headers_for_session,
 )
-from .fixtures import DummyUserTokenDao, fixture_client  # noqa: F401
+from .fixtures import fixture_client  # noqa: F401
 
 
 def expected_set_cookie(session_id: str) -> str:

--- a/tests/integration/auth_adapter/test_totp.py
+++ b/tests/integration/auth_adapter/test_totp.py
@@ -412,7 +412,7 @@ async def test_total_limit_totp(
     assert status_change.by == user_id
     assert status_change.context == "Too many failed TOTP login attempts"
     assert status_change.change_date
-    assert abs((now_as_utc() - status_change.change_date).total_seconds()) < 3
+    assert 0 <= (now_as_utc() - status_change.change_date).total_seconds() < 3
 
     # check that the user is not authorized any more
     response = await client.post("/users", headers=headers)

--- a/tests/integration/auth_adapter/test_totp.py
+++ b/tests/integration/auth_adapter/test_totp.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-"""Test handling TOTP in the auth adapter."""
+"""Test the base TOTP functionality."""
 
 from datetime import datetime
 from random import randint
@@ -24,9 +24,11 @@ from urllib.parse import parse_qs, urlparse
 import pyotp
 from fastapi import status
 from ghga_service_commons.api.testing import AsyncTestClient
+from ghga_service_commons.utils.utc_dates import now_as_utc
 from pytest import mark
 
 from auth_service.auth_adapter.core.session_store import SessionState
+from auth_service.user_management.user_registry.models.dto import UserStatus
 
 from ...fixtures.utils import (  # noqa: F401
     RE_USER_INFO_URL,
@@ -56,14 +58,12 @@ def get_invalid_totp_code(secret: str, when: Optional[datetime] = None) -> str:
     """Generate an invalid TOTP code for the given secret."""
     if not when:
         when = datetime.utcnow()
-    codes: set[str] = set()
     # get the time codes for the tolerance interval
     # plus one more for possible timecode increment during the test
-    for offset in range(-1, 3):
-        codes.add(get_valid_totp_code(secret, when, offset))
+    valid_codes = {get_valid_totp_code(secret, when, offset) for offset in range(-1, 3)}
     for _ in range(10_000):
         code = f"{randint(0, 999_999):06d}"
-        if code not in codes:
+        if code not in valid_codes:
             return code
     raise RuntimeError("Could not find an invalid TOTP code")
 
@@ -207,7 +207,7 @@ async def test_verify_totp(
     client_with_session: ClientWithSession,
 ):
     """Test verification of TOTP tokens."""
-    client, session, user_token_dao = client_with_session
+    client, session, _user_dao, user_token_dao = client_with_session
     headers = headers_for_session(session)
     user_id = "john@ghga.de"
     assert session.state is SessionState.REGISTERED
@@ -249,11 +249,11 @@ async def test_verify_totp(
     assert user_token
     totp_token = user_token.totp_token
     assert len(totp_token.encrypted_secret) == 96
-    assert totp_token.counter
-    assert totp_token.attempts == -1  # verified
+    assert totp_token.last_counter
+    assert totp_token.counter_attempts == -1  # verified
 
     # decrease the TOTP counter so that we can re-login without waiting
-    totp_token.counter -= 1
+    totp_token.last_counter -= 1
 
     # logout and re-login
     response = await client.post("/rpc/logout", headers=headers)
@@ -286,11 +286,11 @@ async def test_verify_totp(
 
 
 @mark.asyncio
-async def test_brute_force_totp(
+async def test_rate_limiting_totp(
     client_with_session: ClientWithSession,
 ):
-    """Test that a bruce force attack fails."""
-    client, session, user_token_dao = client_with_session
+    """Test that the rate limiting for code verification works."""
+    client, session, _user_dao, user_token_dao = client_with_session
     headers = headers_for_session(session)
     user_id = "john@ghga.de"
     assert session.state is SessionState.REGISTERED
@@ -311,7 +311,7 @@ async def test_brute_force_totp(
     assert response.status_code == status.HTTP_204_NO_CONTENT
     # decrease the TOTP counter so that we can re-login without waiting
     totp_token = user_token_dao.user_tokens[user_id].totp_token
-    totp_token.counter -= 1
+    totp_token.last_counter -= 1
     # make 6 attempts with invalid TOTP codes
     # (we might get 3 extra attempts due to time code increment during the test)
     for _ in range(6):
@@ -331,7 +331,7 @@ async def test_brute_force_totp(
     assert response.status_code == status.HTTP_401_UNAUTHORIZED
     assert response.json() == {"detail": "Invalid TOTP code"}
     # reset the TOTP token to make sure it works again
-    totp_token.attempts = 0
+    totp_token.counter_attempts = 0
     response = await client.post(
         "/rpc/verify-totp",
         json={"user_id": user_id, "totp": get_valid_totp_code(secret)},
@@ -342,11 +342,91 @@ async def test_brute_force_totp(
 
 
 @mark.asyncio
+async def test_total_limit_totp(
+    client_with_session: ClientWithSession,
+):
+    """Test that there is a total limit for code verification."""
+    client, session, user_dao, user_token_dao = client_with_session
+    headers = headers_for_session(session)
+
+    user = user_dao.user
+    assert user
+    user_id = user.id
+    assert user_id == "john@ghga.de"
+    assert user.status is UserStatus.ACTIVE
+    assert not user.status_change
+
+    # Check that the user is authorized
+    response = await client.post("/users", headers=headers)
+    assert response.status_code == status.HTTP_200_OK
+    assert not response.text
+    assert "Authorization" in response.headers
+
+    assert session.state is SessionState.REGISTERED
+    # create a new TOTP token on the backend
+    response = await client.post(
+        "/totp-token", json={"user_id": user_id, "force": False}, headers=headers
+    )
+    assert response.status_code == status.HTTP_201_CREATED
+    uri = response.json()["uri"]
+    secret = parse_qs(urlparse(uri).query)["secret"][0]
+    session = await query_new_session(client, session)
+    assert session.state is SessionState.NEW_TOTP_TOKEN
+    response = await client.post(
+        "/rpc/verify-totp",
+        json={"user_id": user_id, "totp": get_valid_totp_code(secret)},
+        headers=headers,
+    )
+    assert response.status_code == status.HTTP_204_NO_CONTENT
+    # decrease the TOTP counter so that we can re-login without waiting
+    totp_token = user_token_dao.user_tokens[user_id].totp_token
+    totp_token.last_counter -= 1
+
+    # make 10 attempts with invalid TOTP codes
+    for _ in range(10):
+        response = await client.post(
+            "/rpc/verify-totp",
+            json={"user_id": user_id, "totp": get_invalid_totp_code(secret)},
+            headers=headers,
+        )
+        assert response.json() == {"detail": "Invalid TOTP code"}
+        totp_token.counter_attempts = 0  # suppress rate limiting
+
+    # now the user should not be verified any more
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+    response = await client.post(
+        "/rpc/verify-totp",
+        json={"user_id": user_id, "totp": get_valid_totp_code(secret)},
+        headers=headers,
+    )
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+    assert response.json() == {"detail": "Too many failed attempts"}
+
+    # check that the user account has been disabled
+    user = user_dao.user
+    assert user
+    assert user.status is UserStatus.INACTIVE
+    status_change = user.status_change
+    assert status_change
+    assert status_change.previous is UserStatus.ACTIVE
+    assert status_change.by == user_id
+    assert status_change.context == "Too many failed TOTP login attempts"
+    assert status_change.change_date
+    assert abs((now_as_utc() - status_change.change_date).total_seconds()) < 3
+
+    # check that the user is not authorized any more
+    response = await client.post("/users", headers=headers)
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+    assert response.json() == {"detail": "Not logged in"}
+    assert "Authorization" not in response.headers
+
+
+@mark.asyncio
 async def test_recreate_existing_totp_token(
     client_with_session: ClientWithSession,
 ):
     """Test that TOTP tokens can be recreated."""
-    client, session, user_token_dao = client_with_session
+    client, session = client_with_session[:2]
     headers = headers_for_session(session)
     user_id = "john@ghga.de"
     assert session.state is SessionState.REGISTERED

--- a/tests/integration/user_management/claims_repository/test_api.py
+++ b/tests/integration/user_management/claims_repository/test_api.py
@@ -304,7 +304,7 @@ def test_grant_download_access(client_with_db):
     assert creation_date
     assert claim_data.pop("assertion_date") == creation_date
     creation_datetime = datetime.fromisoformat(creation_date.replace("Z", "+00:00"))
-    assert abs((current_datetime - creation_datetime).total_seconds()) < 5
+    assert 0 <= (creation_datetime - current_datetime).total_seconds() < 5
 
     assert claim_data == {
         "asserted_by": "dac",

--- a/tests/integration/user_management/claims_repository/test_api.py
+++ b/tests/integration/user_management/claims_repository/test_api.py
@@ -279,8 +279,8 @@ def test_grant_download_access(client_with_db):
     user_dao = DummyUserDao()
     client_with_db.app.dependency_overrides[get_user_dao] = lambda: user_dao
 
-    current_date = now_as_utc()
-    current_year = current_date.year
+    current_datetime = now_as_utc()
+    current_year = current_datetime.year
     validity = {
         "valid_from": f"{current_year - 1}-01-01T00:00:00Z",
         "valid_until": f"{current_year + 1}-12-31T23:59:59Z",
@@ -304,7 +304,7 @@ def test_grant_download_access(client_with_db):
     assert creation_date
     assert claim_data.pop("assertion_date") == creation_date
     creation_datetime = datetime.fromisoformat(creation_date.replace("Z", "+00:00"))
-    assert 0 <= (creation_datetime - current_date).seconds < 5
+    assert abs((current_datetime - creation_datetime).total_seconds()) < 5
 
     assert claim_data == {
         "asserted_by": "dac",

--- a/tests/unit/auth_adapter/test_verify_totp.py
+++ b/tests/unit/auth_adapter/test_verify_totp.py
@@ -141,7 +141,7 @@ async def test_verify_totp(session_state: SessionState, totp_code: str):  # noqa
         assert status_change.by == user_id
         assert status_change.context == "Too many failed TOTP login attempts"
         assert status_change.change_date
-        assert abs((now_as_utc() - status_change.change_date).total_seconds()) < 3
+        assert 0 <= (now_as_utc() - status_change.change_date).total_seconds() < 3
         assert totp_token
         assert not totp_handler.is_invalid(totp_token)
     else:

--- a/tests/unit/auth_adapter/test_verify_totp.py
+++ b/tests/unit/auth_adapter/test_verify_totp.py
@@ -1,0 +1,168 @@
+# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Test the application logic for verifying user TOTP tokens."""
+
+from contextlib import nullcontext
+from typing import cast
+from unittest.mock import AsyncMock, Mock
+
+from fastapi import HTTPException, status
+from ghga_service_commons.utils.utc_dates import now_as_utc
+from pydantic import SecretStr
+from pytest import mark, raises
+
+from auth_service.auth_adapter.adapters.memory_session_store import MemorySessionStore
+from auth_service.auth_adapter.core.session_store import SessionState
+from auth_service.auth_adapter.core.totp import TOTPHandler
+from auth_service.auth_adapter.core.verify_totp import verify_totp
+from auth_service.auth_adapter.ports.dao import UserToken, UserTokenDao
+from auth_service.config import Config
+from auth_service.user_management.user_registry.models.dto import UserStatus
+from auth_service.user_management.user_registry.ports.dao import UserDao
+
+from ...fixtures.utils import DummyUserDao, DummyUserTokenDao
+
+SESSION_ARGS = {
+    "ext_id": "john@aai.org",
+    "user_name": "John Doe",
+    "user_email": "john@home.org",
+    "user_id": "john@ghga.de",
+}
+
+config = Config(
+    totp_encryption_key=SecretStr(TOTPHandler.random_encryption_key()),
+)  # pyright: ignore
+
+
+@mark.asyncio
+@mark.parametrize(
+    "totp_code",
+    ["", "123456", "423715", "123123", "999999"],
+    ids=["empty", "invalid", "valid", "rate-limit", "total-limit"],
+)
+@mark.parametrize(
+    "session_state",
+    [
+        SessionState.REGISTERED,
+        SessionState.NEW_TOTP_TOKEN,
+        SessionState.HAS_TOTP_TOKEN,
+        SessionState.AUTHENTICATED,
+    ],
+)
+async def test_verify_totp(session_state: SessionState, totp_code: str):  # noqa: C901
+    """Test the verification of a TOTP code under various circumstances."""
+    session_store = MemorySessionStore(config=config)
+    session = await session_store.create_session(**SESSION_ARGS)
+    session.state = session_state
+
+    user_has_token = session_state in (
+        SessionState.HAS_TOTP_TOKEN,
+        SessionState.AUTHENTICATED,
+    )
+    session_has_token = session_state is SessionState.NEW_TOTP_TOKEN
+    has_token = user_has_token or session_has_token
+
+    totp_handler = TOTPHandler(config=config)
+    totp_token = totp_handler.generate_token() if has_token else None
+    if totp_token and totp_code == "999999":  # simulate brute force attack
+        totp_token.total_attempts = 10
+        assert totp_handler.is_invalid(totp_token)
+        limit_reached = True
+    else:
+        limit_reached = False
+    session.totp_token = totp_token
+
+    user_dao = DummyUserDao()
+    user_id = user_dao.user.id
+    user_token_dao = DummyUserTokenDao()
+    if user_has_token:
+        assert totp_token
+        await user_token_dao.upsert(UserToken(user_id=user_id, totp_token=totp_token))
+
+    if totp_token:
+        if totp_code == "423715":
+            should_verify = True  # the valid case
+        elif totp_code == "123456":
+            should_verify = False  # the invalid case
+        else:
+            should_verify = None  # the totally invalid or rate-limited case
+    else:
+        should_verify = None  # cannot verify without token
+
+    totp_handler.verify_code = Mock(return_value=should_verify)  # type: ignore
+
+    session_store.save_session = AsyncMock()  # type: ignore
+    session_store.delete_session = AsyncMock()  # type: ignore
+
+    with nullcontext() if should_verify else raises(HTTPException) as exc_info:
+        await verify_totp(
+            totp_code,
+            user_id,
+            session_store=session_store,
+            session=session,
+            totp_handler=totp_handler,
+            user_dao=cast(UserDao, user_dao),
+            token_dao=cast(UserTokenDao, user_token_dao),
+        )
+    if should_verify:
+        assert session.state is SessionState.AUTHENTICATED
+        assert session.totp_token is None
+    else:
+        assert exc_info
+        assert exc_info.value.status_code == status.HTTP_401_UNAUTHORIZED
+        expected_message = (
+            "Too many failed attempts"
+            if limit_reached and has_token
+            else "Invalid TOTP code"
+        )
+        assert exc_info.value.detail == expected_message
+        assert session.state is session_state
+        assert session.totp_token is totp_token
+
+    if limit_reached and user_has_token:
+        assert user_dao.user.status is UserStatus.INACTIVE
+        status_change = user_dao.user.status_change
+        assert status_change
+        assert status_change.previous is UserStatus.ACTIVE
+        assert status_change.by == user_id
+        assert status_change.context == "Too many failed TOTP login attempts"
+        assert status_change.change_date
+        assert abs((now_as_utc() - status_change.change_date).total_seconds()) < 3
+        assert totp_token
+        assert not totp_handler.is_invalid(totp_token)
+    else:
+        assert user_dao.user.status is UserStatus.ACTIVE
+        assert not user_dao.user.status_change
+
+    if limit_reached:
+        session_store.delete_session.assert_awaited_once()
+    else:
+        session_store.delete_session.assert_not_called()
+
+    if should_verify or user_has_token:
+        assert user_token_dao.user_tokens[user_id].totp_token is totp_token
+    else:
+        assert not user_token_dao.user_tokens
+
+    if should_verify is not None or (totp_code and not limit_reached and totp_token):
+        totp_handler.verify_code.assert_called_once_with(totp_token, totp_code)
+    else:
+        totp_handler.verify_code.assert_not_called()
+    if should_verify is not None:
+        session_store.save_session.assert_awaited_once_with(session)
+    else:
+        session_store.save_session.assert_not_called()


### PR DESCRIPTION
In addition to the rate limiting (max. 3 attempts per interval), we now also limit the number of consecutive failed attempts (max. 10 attempts in total). The exact limits are configurable. If the limit is hit, and the TOTP token is already rolled out to the user, the user account is deactivated.