### PR TITLE
Remove unnecessary headers (GSI-651)

### DIFF
--- a/src/auth_service/auth_adapter/deps.py
+++ b/src/auth_service/auth_adapter/deps.py
@@ -37,8 +37,6 @@ from .ports.totp import TOTPHandlerPort
 from .translators.dao import UserTokenDaoFactory
 
 __all__ = [
-    "get_session_store",
-    "get_session",
     "get_user_token_dao",
     "SessionStoreDependency",
     "SessionDependency",


### PR DESCRIPTION
When requests are proxied using the ExtAuth protocol, the original request headers are passed on to the backend, even though some of these headers are processed only by the Auth Adapter and are not relevant for the backend. We now remove these headers from the backend request by setting corresponding empty response headers in the "OK" response from the Auth Adapter.