### PR TITLE
Fix endpoints to work with ExtAuth (GSI-754)

### DIFF
--- a/src/auth_service/auth_adapter/api/dto.py
+++ b/src/auth_service/auth_adapter/api/dto.py
@@ -17,7 +17,7 @@
 
 from pydantic import BaseModel, ConfigDict, Field, SecretStr, field_serializer
 
-__all__ = ["TOTPTokenResponse", "VerifyTOTP"]
+__all__ = ["TOTPTokenResponse"]
 
 
 class BaseDto(BaseModel):
@@ -35,10 +35,3 @@ class TOTPTokenResponse(BaseDto):
     def dump_secret(self, v):
         """Serialize the provisioning URI to a string."""
         return v.get_secret_value()
-
-
-class VerifyTOTP(BaseDto):
-    """Request model for verifying a TOTP code."""
-
-    user_id: str = Field(default=..., title="User ID")
-    totp: str = Field(default=..., title="the TOTP code to verify")

--- a/src/auth_service/auth_adapter/api/dto.py
+++ b/src/auth_service/auth_adapter/api/dto.py
@@ -17,20 +17,13 @@
 
 from pydantic import BaseModel, ConfigDict, Field, SecretStr, field_serializer
 
-__all__ = ["CreateTOTPToken", "TOTPTokenResponse", "VerifyTOTP"]
+__all__ = ["TOTPTokenResponse", "VerifyTOTP"]
 
 
 class BaseDto(BaseModel):
     """Base model pre-configured for use as Dto."""
 
     model_config = ConfigDict(extra="forbid", frozen=True)
-
-
-class CreateTOTPToken(BaseDto):
-    """Request model for creating a TOTP token."""
-
-    user_id: str = Field(default=..., title="User ID")
-    force: bool = Field(default=False, title="Overwrite existing token")
 
 
 class TOTPTokenResponse(BaseDto):

--- a/src/auth_service/auth_adapter/core/verify_totp.py
+++ b/src/auth_service/auth_adapter/core/verify_totp.py
@@ -35,7 +35,6 @@ __all__ = ["verify_totp"]
 
 async def verify_totp(  # noqa: C901, PLR0912, PLR0913
     totp: str,
-    user_id: str,
     *,
     session_store: SessionStorePort,
     session: Session,
@@ -48,6 +47,12 @@ async def verify_totp(  # noqa: C901, PLR0912, PLR0913
     As a side effect, the TOTP token is stored in the database if it is still only
     available in the session, and possibly already verified IVAs are reset.
     """
+    user_id = session.user_id
+    if not user_id:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Not registered",
+        )
     if session.state == SessionState.NEW_TOTP_TOKEN:
         # get not yet verified TOTP token from the session
         user = user_token = None

--- a/tests/integration/auth_adapter/test_api.py
+++ b/tests/integration/auth_adapter/test_api.py
@@ -447,10 +447,10 @@ async def test_random_url_authenticated(client_with_session: ClientWithSession):
     assert response.status_code == status.HTTP_201_CREATED
     uri = response.json()["uri"]
     secret = parse_qs(urlparse(uri).query)["secret"][0]
+    totp = get_valid_totp_code(secret)
     response = await client.post(
         AUTH_PATH + "/rpc/verify-totp",
-        json={"user_id": session.user_id, "totp": get_valid_totp_code(secret)},
-        headers=headers,
+        headers={"X-Authorization": f"Bearer TOTP:{totp}", **headers},
     )
     assert response.status_code == status.HTTP_204_NO_CONTENT
     assert not response.text

--- a/tests/integration/auth_adapter/test_totp.py
+++ b/tests/integration/auth_adapter/test_totp.py
@@ -25,7 +25,7 @@ import pytest
 from fastapi import status
 from ghga_service_commons.utils.utc_dates import now_as_utc
 
-from auth_service.auth_adapter.core.session_store import SessionState
+from auth_service.auth_adapter.core.session_store import Session, SessionState
 from auth_service.auth_adapter.deps import get_config, get_session_store
 from auth_service.user_management.user_registry.models.ivas import IvaState
 from auth_service.user_management.user_registry.models.users import UserStatus
@@ -75,11 +75,25 @@ def get_invalid_totp_code(secret: str, when: datetime | None = None) -> str:
     raise RuntimeError("Could not find an invalid TOTP code")
 
 
-async def test_create_totp_token_without_session(bare_client: BareClient):
-    """Test that TOTP token creation without a session fails."""
-    response = await bare_client.post(TOTP_TOKEN_PATH)
-    assert response.status_code == status.HTTP_401_UNAUTHORIZED
-    assert response.json() == {"detail": "Not logged in"}
+def with_totp_code(
+    headers: dict[str, str], secret: str, valid: bool = True
+) -> dict[str, str]:
+    """Get headers for a valid or invalid TOTP code."""
+    totp = get_valid_totp_code(secret) if valid else get_invalid_totp_code(secret)
+    headers = headers.copy()
+    headers["X-Authorization"] = f"Bearer TOTP:{totp}"
+    return headers
+
+
+async def remove_user_id_from_session(session: Session):
+    """Remove the user ID from the session in the backend."""
+    assert session.user_id
+    session_store = await get_session_store(config=get_config())
+    session_in_store = await session_store.get_session(session.session_id)
+    assert session_in_store
+    assert session_in_store.user_id == session.user_id
+    session_in_store.user_id = None
+    await session_store.save_session(session_in_store)
 
 
 async def test_create_totp_token_with_invalid_force_flag(
@@ -98,15 +112,7 @@ async def test_create_totp_token_without_user_id(
 ):
     """Test that TOTP token creation without a user ID fails."""
     client, session = client_with_session[:2]
-    assert session.user_id
-    # Remove the user ID from the session in the backend
-    # (should always be set for the states in question)
-    session_store = await get_session_store(config=get_config())
-    session_in_store = await session_store.get_session(session.session_id)
-    assert session_in_store
-    assert session_in_store.user_id == session.user_id
-    session_in_store.user_id = None
-    await session_store.save_session(session_in_store)
+    await remove_user_id_from_session(session)
     response = await client.post(TOTP_TOKEN_PATH, headers=headers_for_session(session))
     assert response.status_code == status.HTTP_401_UNAUTHORIZED
     assert response.json() == {"detail": "Not registered"}
@@ -153,28 +159,28 @@ async def test_verify_totp_without_session(bare_client: BareClient):
     assert response.json() == {"detail": "Not logged in"}
 
 
-async def test_verify_totp_without_body(
+async def test_verify_totp_without_x_authorization_header(
     client_with_session: ClientWithSession,
 ):
-    """Test that TOTP verification without request body fails."""
+    """Test that TOTP verification without X-Authorization header fails."""
     client, session = client_with_session[:2]
     response = await client.post(
         VERIFY_TOTP_PATH,
         headers=headers_for_session(session),
     )
-    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+    assert response.json() == {"detail": "No TOTP code provided"}
 
 
-async def test_verify_totp_with_unregistered_user(
+async def test_verify_totp_without_user_id(
     client_with_session: ClientWithSession,
 ):
-    """Test that TOTP token creation with an unregistered user fails."""
+    """Test that TOTP token creation without a user ID fails."""
     client, session = client_with_session[:2]
-    response = await client.post(
-        VERIFY_TOTP_PATH,
-        json={"user_id": "unknown-user-id", "totp": "123456"},
-        headers=headers_for_session(session),
-    )
+    await remove_user_id_from_session(session)
+    headers = headers_for_session(session).copy()
+    headers["X-Authorization"] = "Bearer TOTP:123456"
+    response = await client.post(VERIFY_TOTP_PATH, headers=headers)
     assert response.status_code == status.HTTP_401_UNAUTHORIZED
     assert response.json() == {"detail": "Not registered"}
 
@@ -217,8 +223,7 @@ async def test_verify_totp(client_with_session: ClientWithSession):
     # try to verify with invalid TOTP code
     response = await client.post(
         VERIFY_TOTP_PATH,
-        json={"user_id": user_id, "totp": get_invalid_totp_code(secret)},
-        headers=headers,
+        headers=with_totp_code(headers, secret, valid=False),
     )
     assert response.status_code == status.HTTP_401_UNAUTHORIZED
     assert response.json() == {"detail": "Invalid TOTP code"}
@@ -227,8 +232,7 @@ async def test_verify_totp(client_with_session: ClientWithSession):
     # verify with valid TOTP code
     response = await client.post(
         VERIFY_TOTP_PATH,
-        json={"user_id": user_id, "totp": get_valid_totp_code(secret)},
-        headers=headers,
+        headers=with_totp_code(headers, secret),
     )
     assert response.status_code == status.HTTP_204_NO_CONTENT
     assert not response.text
@@ -262,16 +266,14 @@ async def test_verify_totp(client_with_session: ClientWithSession):
     # again, first try to verify with invalid TOTP code
     response = await client.post(
         VERIFY_TOTP_PATH,
-        json={"user_id": user_id, "totp": get_invalid_totp_code(secret)},
-        headers=headers,
+        headers=with_totp_code(headers, secret, valid=False),
     )
     assert response.status_code == status.HTTP_401_UNAUTHORIZED
     assert response.json() == {"detail": "Invalid TOTP code"}
     # then verify with valid TOTP code
     response = await client.post(
         VERIFY_TOTP_PATH,
-        json={"user_id": user_id, "totp": get_valid_totp_code(secret)},
-        headers=headers,
+        headers=with_totp_code(headers, secret),
     )
     assert response.status_code == status.HTTP_204_NO_CONTENT
     assert not response.text
@@ -297,8 +299,7 @@ async def test_rate_limiting_totp(
     assert session.state is SessionState.NEW_TOTP_TOKEN
     response = await client.post(
         VERIFY_TOTP_PATH,
-        json={"user_id": user_id, "totp": get_valid_totp_code(secret)},
-        headers=headers,
+        headers=with_totp_code(headers, secret),
     )
     assert response.status_code == status.HTTP_204_NO_CONTENT
     # decrease the TOTP counter so that we can re-login without waiting
@@ -309,16 +310,14 @@ async def test_rate_limiting_totp(
     for _ in range(6):
         response = await client.post(
             VERIFY_TOTP_PATH,
-            json={"user_id": user_id, "totp": get_invalid_totp_code(secret)},
-            headers=headers,
+            headers=with_totp_code(headers, secret, valid=False),
         )
         assert response.json() == {"detail": "Invalid TOTP code"}
     # now the user should not be verified any more
     assert response.status_code == status.HTTP_401_UNAUTHORIZED
     response = await client.post(
         VERIFY_TOTP_PATH,
-        json={"user_id": user_id, "totp": get_valid_totp_code(secret)},
-        headers=headers,
+        headers=with_totp_code(headers, secret),
     )
     assert response.status_code == status.HTTP_401_UNAUTHORIZED
     assert response.json() == {"detail": "Invalid TOTP code"}
@@ -326,8 +325,7 @@ async def test_rate_limiting_totp(
     totp_token.counter_attempts = 0
     response = await client.post(
         VERIFY_TOTP_PATH,
-        json={"user_id": user_id, "totp": get_valid_totp_code(secret)},
-        headers=headers,
+        headers=with_totp_code(headers, secret),
     )
     assert response.status_code == status.HTTP_204_NO_CONTENT
     assert not response.text
@@ -360,8 +358,7 @@ async def test_total_limit_totp(client_with_session: ClientWithSession):
     assert session.state is SessionState.NEW_TOTP_TOKEN
     response = await client.post(
         VERIFY_TOTP_PATH,
-        json={"user_id": user_id, "totp": get_valid_totp_code(secret)},
-        headers=headers,
+        headers=with_totp_code(headers, secret),
     )
     assert response.status_code == status.HTTP_204_NO_CONTENT
     # decrease the TOTP counter so that we can re-login without waiting
@@ -372,8 +369,7 @@ async def test_total_limit_totp(client_with_session: ClientWithSession):
     for _ in range(10):
         response = await client.post(
             VERIFY_TOTP_PATH,
-            json={"user_id": user_id, "totp": get_invalid_totp_code(secret)},
-            headers=headers,
+            headers=with_totp_code(headers, secret, valid=False),
         )
         assert response.json() == {"detail": "Invalid TOTP code"}
         totp_token.counter_attempts = 0  # suppress rate limiting
@@ -382,8 +378,7 @@ async def test_total_limit_totp(client_with_session: ClientWithSession):
     assert response.status_code == status.HTTP_401_UNAUTHORIZED
     response = await client.post(
         VERIFY_TOTP_PATH,
-        json={"user_id": user_id, "totp": get_valid_totp_code(secret)},
-        headers=headers,
+        headers=with_totp_code(headers, secret),
     )
     assert response.status_code == status.HTTP_401_UNAUTHORIZED
     assert response.json() == {"detail": "Too many failed attempts"}
@@ -412,7 +407,6 @@ async def test_recreate_existing_totp_token(
     """Test that TOTP tokens can be recreated."""
     client, session = client_with_session[:2]
     headers = headers_for_session(session)
-    user_id = "john@ghga.de"
     assert session.state is SessionState.REGISTERED
 
     # create a new TOTP token on the backend
@@ -424,8 +418,7 @@ async def test_recreate_existing_totp_token(
     assert session.state is SessionState.NEW_TOTP_TOKEN
     response = await client.post(
         VERIFY_TOTP_PATH,
-        json={"user_id": user_id, "totp": get_valid_totp_code(secret)},
-        headers=headers,
+        headers=with_totp_code(headers, secret),
     )
     assert response.status_code == status.HTTP_204_NO_CONTENT
 
@@ -446,15 +439,13 @@ async def test_recreate_existing_totp_token(
     # cannot login with old secret any more
     response = await client.post(
         VERIFY_TOTP_PATH,
-        json={"user_id": user_id, "totp": get_valid_totp_code(secret)},
-        headers=headers,
+        headers=with_totp_code(headers, secret),
     )
     assert response.status_code == status.HTTP_401_UNAUTHORIZED
     assert response.json() == {"detail": "Invalid TOTP code"}
     # but can login with new secret now
     response = await client.post(
         VERIFY_TOTP_PATH,
-        json={"user_id": user_id, "totp": get_valid_totp_code(new_secret)},
-        headers=headers,
+        headers=with_totp_code(headers, new_secret),
     )
     assert response.status_code == status.HTTP_204_NO_CONTENT

--- a/tests/unit/auth_adapter/test_verify_totp.py
+++ b/tests/unit/auth_adapter/test_verify_totp.py
@@ -60,6 +60,7 @@ config = Config(
 @pytest.mark.parametrize(
     "session_state",
     [
+        SessionState.NEEDS_REGISTRATION,
         SessionState.REGISTERED,
         SessionState.NEW_TOTP_TOKEN,
         SessionState.HAS_TOTP_TOKEN,
@@ -98,6 +99,7 @@ async def test_verify_totp(session_state: SessionState, totp_code: str):  # noqa
     user_token_dao = DummyUserTokenDao()
 
     user_id = user_dao.user.id
+    assert user_id == session.user_id
     if user_has_token:
         assert totp_token
         await user_token_dao.upsert(UserToken(user_id=user_id, totp_token=totp_token))
@@ -122,7 +124,6 @@ async def test_verify_totp(session_state: SessionState, totp_code: str):  # noqa
     with nullcontext() if should_verify else pytest.raises(HTTPException) as exc_info:
         await verify_totp(
             totp_code,
-            user_id,
             session_store=session_store,
             session=session,
             totp_handler=totp_handler,


### PR DESCRIPTION
The two endpoints `/totp-token` and `/rpc/verify-totp` had a conceptual problem: They used the request body, but the ExtAuth protocol does not pass it along with the request - such endpoints can only use query params or configured headers.

Therefore, this PR redesigns these endpoints a bit:

- Remove the `user_id` as input from these endpoints, and derive it from the session instead.
- The `force` field in `totp-token` has been converted to a query parameter.
- The `code` field in `/rpc/verify-totp` is passed in the X-Authorization header like a bearer token. The value of the header should look like `Bearer TOTP:123456`.
