### PR TITLE
Publish user dto with user_id (GSI-769)

### DIFF
--- a/.pyproject_generation/pyproject_custom.toml
+++ b/.pyproject_generation/pyproject_custom.toml
@@ -1,6 +1,6 @@
 [project]
 name = "auth_service"
-version = "2.4.0"
+version = "2.4.1"
 description = "Authentication adapter and services used for the GHGA data portal"
 dependencies = [
     "ghga-event-schemas==3.3.0",

--- a/README.md
+++ b/README.md
@@ -49,13 +49,13 @@ We recommend using the provided Docker container.
 
 A pre-build version is available at [docker hub](https://hub.docker.com/repository/docker/ghga/auth-service):
 ```bash
-docker pull ghga/auth-service:2.4.0
+docker pull ghga/auth-service:2.4.1
 ```
 
 Or you can build the container yourself from the [`./Dockerfile`](./Dockerfile):
 ```bash
 # Execute in the repo's root dir:
-docker build -t ghga/auth-service:2.4.0 .
+docker build -t ghga/auth-service:2.4.1 .
 ```
 
 For production-ready deployment, we recommend using Kubernetes, however,
@@ -63,7 +63,7 @@ for simple use cases, you could execute the service using docker
 on a single server:
 ```bash
 # The entrypoint is preconfigured:
-docker run -p 8080:8080 ghga/auth-service:2.4.0 --help
+docker run -p 8080:8080 ghga/auth-service:2.4.1 --help
 ```
 
 If you prefer not to use containers, you may install the service from source:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -939,7 +939,7 @@ info:
   license:
     name: Apache 2.0
   title: User Management API
-  version: 2.4.0
+  version: 2.4.1
 openapi: 3.1.0
 paths:
   /download-access/users/{user_id}/datasets:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Intended Audience :: Developers",
 ]
 name = "auth_service"
-version = "2.4.0"
+version = "2.4.1"
 description = "Authentication adapter and services used for the GHGA data portal"
 dependencies = [
     "ghga-event-schemas==3.3.0",

--- a/src/auth_service/user_management/user_registry/translators/dao.py
+++ b/src/auth_service/user_management/user_registry/translators/dao.py
@@ -74,7 +74,7 @@ class UserDaoPublisherFactory(UserDaoPublisherFactoryPort):
             user_id=user.id,
             name=user.name,
             email=user.email,
-            title=user.title.value if user.title else None,  # type: ignore
+            title=user.title.value if user.title else None,
         )
         return validated_user.model_dump()
 

--- a/src/auth_service/user_management/user_registry/translators/dao.py
+++ b/src/auth_service/user_management/user_registry/translators/dao.py
@@ -16,6 +16,7 @@
 
 """Translation between general and user specific DAOs."""
 
+from ghga_event_schemas import pydantic_ as event_schemas
 from hexkit.custom_types import JsonObject
 from hexkit.protocols.daopub import DaoPublisher, DaoPublisherFactoryProtocol
 from pydantic import Field
@@ -69,12 +70,13 @@ class UserDaoPublisherFactory(UserDaoPublisherFactoryPort):
     @staticmethod
     def _user_to_event(user: UserDto) -> JsonObject:
         """Translate a user to an event."""
-        return {
-            "id": user.id,
-            "name": user.name,
-            "email": user.email,
-            "title": user.title.value if user.title else None,
-        }
+        validated_user = event_schemas.User(
+            user_id=user.id,
+            name=user.name,
+            email=user.email,
+            title=user.title.value if user.title else None,  # type: ignore
+        )
+        return validated_user.model_dump()
 
     async def get_user_dao(self) -> DaoPublisher[UserDto]:
         """Construct a DAO for interacting with user data in a database.

--- a/tests/integration/user_management/user_registry/test_api.py
+++ b/tests/integration/user_management/user_registry/test_api.py
@@ -101,7 +101,7 @@ async def test_post_user(full_client: FullClient, new_user_headers: dict[str, st
     assert recorder.recorded_events == [
         RecordedEvent(
             payload={
-                "id": id_,
+                "user_id": id_,
                 "name": "Max Headroom",
                 "email": "max@example.org",
                 "title": "Dr.",
@@ -149,7 +149,7 @@ async def test_post_user_with_minimal_data(
     assert recorder.recorded_events == [
         RecordedEvent(
             payload={
-                "id": id_,
+                "user_id": id_,
                 "name": "Max Headroom",
                 "email": "max@example.org",
                 "title": None,
@@ -283,7 +283,7 @@ async def test_put_user(full_client: FullClient, new_user_headers: dict[str, str
     assert recorder.recorded_events == [
         RecordedEvent(
             payload={
-                "id": id_,
+                "user_id": id_,
                 "name": "Max Headhall",
                 "email": "head@example.org",
                 "title": "Prof.",

--- a/tests/integration/user_management/user_registry/test_dao.py
+++ b/tests/integration/user_management/user_registry/test_dao.py
@@ -96,7 +96,7 @@ async def test_user_crud(
     assert recorder.recorded_events == [
         RecordedEvent(
             payload={
-                "id": user.id,
+                "user_id": user.id,
                 "name": user.name,
                 "email": user.email,
                 "title": user.title,
@@ -106,7 +106,7 @@ async def test_user_crud(
         ),
         RecordedEvent(
             payload={
-                "id": user.id,
+                "user_id": user.id,
                 "name": user.name,
                 "email": changed_user.email,
                 "title": user.title,


### PR DESCRIPTION
The dto_to_event method of the outbox publisher used for Users in the Auth Service currently uses 'id' as a payload representation. However, the GHGA-event-schema model User expects a `user_id` field.