### PR TITLE
Determine JWT config only when required

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,7 +374,7 @@ The service requires the following configuration parameters:
 
 - **`api_ext_path`** *(string)*: external API path for the auth related endpoints (user, session and TOTP management). Default: `"/api/auth"`.
 
-- **`auth_ext_keys`**: external public key set for auth adapter (not used for user management). Default: `null`.
+- **`auth_ext_keys`**: external public key set for auth adapter (used only by the auth adapter, determined using OIDC discovery if None). Default: `null`.
 
   - **Any of**
 
@@ -420,7 +420,15 @@ The service requires the following configuration parameters:
 
 - **`oidc_authority_url`** *(string, format: uri)*: external OIDC authority URL used by the auth adapter. Default: `"https://login.aai.lifescience-ri.eu/oidc/"`.
 
-- **`oidc_userinfo_endpoint`**: external OIDC userinfo endpoint used by the auth adapter. Default: `"https://login.aai.lifescience-ri.eu/oidc/userinfo"`.
+- **`oidc_issuer`**: external OIDC issuer for access tokens used by the auth adapter (determined using OIDC discovery if None). Default: `"https://login.aai.lifescience-ri.eu/oidc/"`.
+
+  - **Any of**
+
+    - *string, format: uri*
+
+    - *null*
+
+- **`oidc_userinfo_endpoint`**: external OIDC userinfo endpoint used by the auth adapter (determined using OIDC discovery if None). Default: `"https://login.aai.lifescience-ri.eu/oidc/userinfo"`.
 
   - **Any of**
 

--- a/config_schema.json
+++ b/config_schema.json
@@ -521,7 +521,7 @@
         }
       ],
       "default": null,
-      "description": "external public key set for auth adapter (not used for user management)",
+      "description": "external public key set for auth adapter (used only by the auth adapter, determined using OIDC discovery if None)",
       "title": "Auth Ext Keys"
     },
     "auth_ext_algs": {
@@ -616,6 +616,22 @@
       "title": "Oidc Authority Url",
       "type": "string"
     },
+    "oidc_issuer": {
+      "anyOf": [
+        {
+          "format": "uri",
+          "maxLength": 2083,
+          "minLength": 1,
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": "https://login.aai.lifescience-ri.eu/oidc/",
+      "description": "external OIDC issuer for access tokens used by the auth adapter (determined using OIDC discovery if None)",
+      "title": "Oidc Issuer"
+    },
     "oidc_userinfo_endpoint": {
       "anyOf": [
         {
@@ -629,7 +645,7 @@
         }
       ],
       "default": "https://login.aai.lifescience-ri.eu/oidc/userinfo",
-      "description": "external OIDC userinfo endpoint used by the auth adapter",
+      "description": "external OIDC userinfo endpoint used by the auth adapter (determined using OIDC discovery if None)",
       "title": "Oidc Userinfo Endpoint"
     },
     "oidc_client_id": {

--- a/example_config.yaml
+++ b/example_config.yaml
@@ -53,6 +53,7 @@ log_level: DEBUG
 max_iva_verification_attempts: 10
 oidc_authority_url: https://login.aai.lifescience-ri.eu/oidc/
 oidc_client_id: ghga-data-portal
+oidc_issuer: https://login.aai.lifescience-ri.eu/oidc/
 oidc_userinfo_endpoint: https://login.aai.lifescience-ri.eu/oidc/userinfo
 openapi_url: /openapi.json
 organization_url: https://ghga.de/

--- a/src/auth_service/auth_adapter/core/auth.py
+++ b/src/auth_service/auth_adapter/core/auth.py
@@ -31,7 +31,7 @@ from auth_service.config import CONFIG, Config
 
 from .session_store import Session
 
-__all__ = ["get_user_info", "internal_token_from_session", "jwt_config"]
+__all__ = ["get_user_info", "internal_token_from_session", "get_jwt_config"]
 
 log = logging.getLogger(__name__)
 
@@ -120,7 +120,7 @@ class OIDCDiscovery:
             raise ConfigurationDiscoveryError("Unexpected JWKS object")
         return jwks_response.text
 
-    @property
+    @cached_property
     def token_endpoint(self) -> str:
         """Fetch the URL of the token endpoint."""
         token_endpoint = self.config.get("token_endpoint")
@@ -129,7 +129,7 @@ class OIDCDiscovery:
         log.info("Discovered token endpoint: %s", token_endpoint)
         return token_endpoint
 
-    @property
+    @cached_property
     def userinfo_endpoint(self) -> str:
         """Fetch the URL of the userinfo endpoint."""
         userinfo_endpoint = self.config.get("userinfo_endpoint")
@@ -166,7 +166,7 @@ class JWTConfig:
 
         external_keys = config.auth_ext_keys
         if not external_keys:
-            log.warning("No external signing keys configured, using discovery.")
+            log.info("No external signing keys configured, using discovery.")
             external_keys = discovery.jwks_str
         external_jwks = jwk.JWKSet.from_json(external_keys)
         if not any(external_jwk.has_public for external_jwk in external_jwks):
@@ -192,7 +192,13 @@ class JWTConfig:
         else:
             log.warning("Allowed external signing algorithms not configured.")
             self.external_algs = None
-        self.check_at_claims["iss"] = discovery.issuer
+
+        issuer = str(config.oidc_issuer)
+        if not issuer:
+            log.info("No issuer configured, using discovery.")
+        log.debug("Using OIDC issuer: %s", issuer)
+        self.check_at_claims["iss"] = issuer
+
         client_id = config.oidc_client_id
         if client_id:
             self.check_at_claims["client_id"] = client_id
@@ -202,19 +208,31 @@ class JWTConfig:
 
         userinfo_endpoint = str(config.oidc_userinfo_endpoint)
         if not userinfo_endpoint:
-            log.warning("No external userinfo endpoint configured, using discovery.")
-            userinfo_endpoint = str(discovery.userinfo_endpoint)
+            log.info("No external userinfo endpoint configured, using discovery.")
+            userinfo_endpoint = discovery.userinfo_endpoint
+        log.debug("Using OIDC issuer: %s", issuer)
         self.userinfo_endpoint = userinfo_endpoint
 
 
-jwt_config = JWTConfig()
+_jwt_config: JWTConfig | None = None
+
+
+def get_jwt_config() -> JWTConfig:
+    """Get the JWT configuration only when required.
+
+    This allows the auth adapter to start even if OIDC discovery fails.
+    """
+    global _jwt_config
+    if _jwt_config is None:
+        _jwt_config = JWTConfig()
+    return _jwt_config
 
 
 @lru_cache(maxsize=1024)
 def _fetch_user_info(access_token: str) -> dict[str, Any]:
     """Fetch info for the given access token from the userinfo endpoint."""
     response = httpx.get(
-        jwt_config.userinfo_endpoint,
+        get_jwt_config().userinfo_endpoint,
         headers={"Authorization": f"Bearer {access_token}"},
     )
     if response.status_code != status.HTTP_200_OK:
@@ -230,7 +248,7 @@ def _assert_at_claims_not_empty(at_claims: dict[str, Any]) -> None:
 
     Raises a TokenValidationError in case one of the claims is empty.
     """
-    for claim in jwt_config.check_at_claims:
+    for claim in get_jwt_config().check_at_claims:
         if not at_claims[claim]:
             raise TokenValidationError(f"Missing value for {claim} claim.")
 
@@ -240,13 +258,13 @@ def _assert_ui_claims_not_empty(ui_claims: dict[str, Any]) -> None:
 
     Raises a UserInfoError in case one of the claims is empty.
     """
-    for claim in jwt_config.check_ui_claims:
+    for claim in get_jwt_config().check_ui_claims:
         if not ui_claims.get(claim):
             raise UserInfoError(f"Missing value for {claim} claim.")
 
 
 def decode_and_validate_token(
-    access_token: str, key: jwk.JWK | jwk.JWKSet = jwt_config.external_jwks
+    access_token: str, key: jwk.JWK | jwk.JWKSet | None = None
 ) -> dict[str, Any]:
     """Decode and validate the given JSON Web Token.
 
@@ -256,6 +274,9 @@ def decode_and_validate_token(
     """
     if not access_token:
         raise TokenValidationError("Empty token")
+    jwt_config = get_jwt_config()
+    if not key:
+        key = jwt_config.external_jwks
     try:
         token = jwt.JWT(
             jwt=access_token,
@@ -272,9 +293,7 @@ def decode_and_validate_token(
         raise TokenValidationError("Claims cannot be decoded") from exc
 
 
-def sign_and_encode_token(
-    claims: dict[str, Any], key: jwk.JWK = jwt_config.internal_jwk
-) -> str:
+def sign_and_encode_token(claims: dict[str, Any], key: jwk.JWK | None = None) -> str:
     """Encode and sign the given payload as JSON Web Token.
 
     Returns the signed and encoded payload.
@@ -283,6 +302,8 @@ def sign_and_encode_token(
     """
     if not claims:
         raise TokenSigningError("No payload")
+    if not key:
+        key = get_jwt_config().internal_jwk
     header = {"alg": "ES256" if key["kty"] == "EC" else "RS256", "typ": "JWT"}
     try:
         token = jwt.JWT(header=header, claims=claims)

--- a/src/auth_service/config.py
+++ b/src/auth_service/config.py
@@ -82,7 +82,7 @@ class Config(
     auth_ext_keys: str | None = Field(
         default=None,
         description="external public key set for auth adapter"
-        " (not used for user management)",
+        " (used only by the auth adapter, determined using OIDC discovery if None)",
     )
     auth_ext_algs: list[str] = Field(
         default=["RS256", "ES256"],
@@ -122,9 +122,15 @@ class Config(
         default="https://login.aai.lifescience-ri.eu/oidc/",
         description="external OIDC authority URL used by the auth adapter",
     )
+    oidc_issuer: HttpUrl | None = Field(
+        default="https://login.aai.lifescience-ri.eu/oidc/",
+        description="external OIDC issuer for access tokens used by the auth adapter"
+        " (determined using OIDC discovery if None)",
+    )
     oidc_userinfo_endpoint: HttpUrl | None = Field(
         default="https://login.aai.lifescience-ri.eu/oidc/userinfo",
-        description="external OIDC userinfo endpoint used by the auth adapter",
+        description="external OIDC userinfo endpoint used by the auth adapter"
+        " (determined using OIDC discovery if None)",
     )
     oidc_client_id: str = Field(
         default="ghga-data-portal", description="the registered OIDC client ID"

--- a/tests/unit/auth_adapter/test_token_validation.py
+++ b/tests/unit/auth_adapter/test_token_validation.py
@@ -99,17 +99,18 @@ def test_does_not_validate_an_access_token_with_bad_signature():
 def test_does_not_validate_an_access_token_when_alg_is_not_allowed():
     """Test that an access token must be signed with an allowed algorithm."""
     access_token = create_access_token()
-    external_algs = auth.jwt_config.external_algs
+    jwt_config = auth.get_jwt_config()
+    external_algs = jwt_config.external_algs
     assert isinstance(external_algs, list)
-    auth.jwt_config.external_algs = external_algs[:]
+    jwt_config.external_algs = external_algs[:]
     try:
-        auth.jwt_config.external_algs.remove("ES256")
+        jwt_config.external_algs.remove("ES256")
         with pytest.raises(
             auth.TokenValidationError, match="Not a valid token: Missing Key"
         ):
             auth.decode_and_validate_token(access_token)
     finally:
-        auth.jwt_config.external_algs = external_algs
+        jwt_config.external_algs = external_algs
 
 
 def test_does_not_validate_an_access_token_with_invalid_client_id():
@@ -145,8 +146,9 @@ def test_does_not_validate_an_expired_access_token():
 def test_does_not_validate_token_with_invalid_payload():
     """Test that access tokens with invalid payload are rejected."""
     key = jwk.JWK(kty="oct", k="r0TSf_aAU9eS7I5JPPJ20pmkPmR__9LsfnZaKfXZYp8")
-    external_algs = auth.jwt_config.external_algs
-    auth.jwt_config.external_algs = ["HS256"]
+    jwt_config = auth.get_jwt_config()
+    external_algs = jwt_config.external_algs
+    jwt_config.external_algs = ["HS256"]
     try:
         token_with_valid_payload = (
             "eyJhbGciOiJIUzI1NiJ9."
@@ -176,4 +178,4 @@ def test_does_not_validate_token_with_invalid_payload():
         ):
             auth.decode_and_validate_token(token_with_bad_encoding, key=key)
     finally:
-        auth.jwt_config.external_algs = external_algs
+        jwt_config.external_algs = external_algs


### PR DESCRIPTION
When the auth adapter starts, and OIDC discovery is done via the API gateway, this will not work because the API gateway needs the auth adaptr. Therefore we postpoine OIDC discovery to when it is actually required.