### PR TITLE
Fix preparation of auth adapter

### DIFF
--- a/src/auth_service/__main__.py
+++ b/src/auth_service/__main__.py
@@ -24,13 +24,16 @@ from ghga_service_commons.utils.utc_dates import assert_tz_is_utc
 from hexkit.log import configure_logging
 
 from .config import CONFIG, Config
-from .prepare import prepare_opentelemetry
+from .otel import prepare_opentelemetry
 
 log = logging.getLogger(__name__)
 
 
 def import_prepare_module(auth_adapter: bool):
-    """Import the prepare module."""
+    """Import the prepare module.
+
+    This should only be imported once we know which service should be run.
+    """
     package = "auth_service"
     if auth_adapter:
         package += ".auth_adapter"

--- a/src/auth_service/otel.py
+++ b/src/auth_service/otel.py
@@ -1,0 +1,40 @@
+# Copyright 2021 - 2025 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Bae OpenTelemetry support for all included services."""
+
+import logging
+from os import environ
+
+from opentelemetry import trace
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk.resources import SERVICE_NAME, Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+
+log = logging.getLogger(__name__)
+
+
+def prepare_opentelemetry(service_name: str) -> None:
+    """Initialize OpenTelemetry tracing."""
+    if environ.get("OTEL_SDK_DISABLE"):
+        log.info("OpenTelemetry tracing is disabled")
+        return
+    log.info("Setting up OpenTelemetry tracing")
+    resource = Resource(attributes={SERVICE_NAME: service_name})
+    trace_provider = TracerProvider(resource=resource)
+    processor = BatchSpanProcessor(OTLPSpanExporter())
+    trace_provider.add_span_processor(processor)
+    trace.set_tracer_provider(trace_provider)

--- a/src/auth_service/prepare.py
+++ b/src/auth_service/prepare.py
@@ -24,11 +24,6 @@ from hexkit.providers.akafka import KafkaEventPublisher
 from hexkit.providers.akafka.provider import KafkaEventSubscriber
 from hexkit.providers.mongodb import MongoDbDaoFactory
 from hexkit.providers.mongokafka import MongoKafkaDaoPublisherFactory
-from opentelemetry import trace
-from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
-from opentelemetry.sdk.resources import SERVICE_NAME, Resource
-from opentelemetry.sdk.trace import TracerProvider
-from opentelemetry.sdk.trace.export import BatchSpanProcessor
 
 from auth_service.auth_adapter.deps import get_user_token_dao
 from auth_service.auth_adapter.translators.dao import UserTokenDaoFactory
@@ -159,12 +154,3 @@ async def prepare_rest_app(config: Config) -> AsyncGenerator[FastAPI, None]:
             )
 
         yield app
-
-
-def prepare_opentelemetry(service_name: str) -> None:
-    """Initialize OpenTelemetry tracing."""
-    resource = Resource(attributes={SERVICE_NAME: service_name})
-    trace_provider = TracerProvider(resource=resource)
-    processor = BatchSpanProcessor(OTLPSpanExporter())
-    trace_provider.add_span_processor(processor)
-    trace.set_tracer_provider(trace_provider)

--- a/tests/fixtures/auth_keys.py
+++ b/tests/fixtures/auth_keys.py
@@ -24,6 +24,7 @@ from typing import Any
 
 from jwcrypto import jwk
 
+from auth_service.auth_adapter.core.totp import TOTPHandler
 from auth_service.config import CONFIG
 
 auth_adapter = "auth_adapter" in CONFIG.provide_apis
@@ -71,6 +72,7 @@ def generate_keys() -> dict[str, Any]:
                 "TEST_AUTH_SERVICE_AUTH_EXT_KEYS": ext_keys(private_keys=True),
             }
         )
+        env["AUTH_SERVICE_TOTP_ENCRYPTION_KEY"] = TOTPHandler.random_encryption_key()
     else:
         env.update(
             {


### PR DESCRIPTION
After the last refactoring, the routers of the user registry were imported even when only the auth adapter was started. Since the routers do some initialization that require the proper keys to be setup, this could cause a configuration failure. The PR now imports the routers that are really required. It also initializes the TOTP key when starting the auth adapter using the dev launcher.