### PR TITLE
Add endpoints for access management

### DIFF
--- a/src/auth_service/claims_repository/core/claims.py
+++ b/src/auth_service/claims_repository/core/claims.py
@@ -147,13 +147,27 @@ def create_controlled_access_claim(
     )
 
 
-def create_controlled_access_filter(dataset_id: str) -> dict[str, str]:
-    """Create a mapping for filtering controlled access grants for a given dataset."""
-    return {
+def create_controlled_access_filter(
+    *,
+    user_id: str | None = None,
+    iva_id: str | None = None,
+    dataset_id: str | None = None,
+) -> dict[str, str]:
+    """Create a mapping for filtering controlled access grants.
+
+    If a user, IVA or dataset ID is given, filter values will be set accordingly.
+    """
+    mapping = {
         "visa_type": VisaType.CONTROLLED_ACCESS_GRANTS.value,
-        "visa_value": DATASET_PREFIX + dataset_id,
         "source": str(INTERNAL_SOURCE).rstrip("/"),
     }
+    if user_id:
+        mapping["user_id"] = user_id
+    if iva_id:
+        mapping["iva_id"] = iva_id
+    if dataset_id:
+        mapping["visa_value"] = DATASET_PREFIX + dataset_id
+    return mapping
 
 
 def get_dataset_for_value(value: str) -> str | None:

--- a/src/auth_service/claims_repository/core/deletion.py
+++ b/src/auth_service/claims_repository/core/deletion.py
@@ -34,7 +34,7 @@ class DatasetDeletionHandler(DatasetDeletionPort):
 
     async def handle_dataset_deletion(self, *, dataset_id: str) -> None:
         """Delete all access rights for datasets with the given id."""
-        claims_filter = create_controlled_access_filter(dataset_id)
+        claims_filter = create_controlled_access_filter(dataset_id=dataset_id)
         count_deleted = 0
         async for dataset in self.claim_dao.find_all(mapping=claims_filter):
             await self.claim_dao.delete(dataset.id)

--- a/src/auth_service/claims_repository/models/claims.py
+++ b/src/auth_service/claims_repository/models/claims.py
@@ -213,3 +213,35 @@ class Claim(ClaimCreation):
     revocation_date: UTCDatetime | None = Field(
         default=None, description="If revoked, date of revocation"
     )
+
+
+class Grant(BaseDto):
+    """An access grant based on a corresponding claim."""
+
+    id: str = Field(  # actually UUID
+        ..., description="Internal grant ID (same as claim ID)"
+    )
+    user_id: str = Field(  # actually UUID
+        default=..., description="Internal user ID"
+    )
+    iva_id: str | None = Field(  # actually UUID
+        default=None, description="ID of an IVA associated with this grant"
+    )
+    dataset_id: Accession = Field(
+        default=..., description="ID of the dataset this grant is for"
+    )
+
+    created: UTCDatetime = Field(
+        default=..., description="Date of creation of this grant"
+    )
+    valid_from: UTCDatetime = Field(default=..., description="Start date of validity")
+    valid_until: UTCDatetime = Field(default=..., description="End date of validity")
+
+    user_name: str = Field(default=..., description="Full name of the user")
+    user_email: EmailStr = Field(
+        default=...,
+        description="The email address of the user",
+    )
+    user_title: str | None = Field(
+        default=None, description="Academic title of the user"
+    )

--- a/src/auth_service/claims_repository/rest/access_router.py
+++ b/src/auth_service/claims_repository/rest/access_router.py
@@ -18,27 +18,31 @@
 
 import logging
 from enum import Enum
+from operator import attrgetter
 from typing import Annotated
 
-from fastapi import APIRouter, Path, Response, status
+from fastapi import APIRouter, Path, Query, Response, status
 from fastapi.exceptions import HTTPException
 from ghga_service_commons.utils.utc_dates import UTCDatetime
 from hexkit.opentelemetry import start_span
+from hexkit.protocols.dao import ResourceNotFoundError
 
 from auth_service.user_registry.deps import (
     IvaDaoDependency,
     UserDaoDependency,
 )
 
+from ...user_registry.models.users import User
 from ..core.claims import (
     create_controlled_access_claim,
+    create_controlled_access_filter,
     dataset_id_for_download_access,
     has_download_access_for_dataset,
     is_valid_claim,
 )
 from ..core.utils import iva_is_verified, user_is_active, user_with_iva_exists
 from ..deps import ClaimDaoDependency
-from ..models.claims import Accession, ClaimValidity, VisaType
+from ..models.claims import Accession, ClaimValidity, Grant
 
 __all__ = ["router"]
 
@@ -55,6 +59,107 @@ iva_not_found_error = HTTPException(
 )
 
 TAGS: list[str | Enum] = ["access"]
+
+
+@start_span()
+@router.get(
+    "/download-access/grants",
+    operation_id="get_download_access_grants",
+    tags=TAGS,
+    summary="Get access grants",
+    description="Endpoint to get the list of all access grants. Can be filtered by user ID, IVA ID, and dataset ID.",
+    responses={
+        200: {
+            "model": list[Grant],
+            "description": "Access grants have been fetched.",
+        },
+    },
+    status_code=200,
+)
+async def get_download_access_grants(  # noqa: PLR0913
+    claim_dao: ClaimDaoDependency,
+    user_dao: UserDaoDependency,
+    user_id: Annotated[
+        str | None,
+        Query(
+            ...,
+            alias="user_id",
+            description="The internal ID of the user",
+        ),
+    ] = None,
+    iva_id: Annotated[
+        str | None,
+        Query(
+            ...,
+            alias="iva_id",
+            description="The ID of the IVA",
+        ),
+    ] = None,
+    dataset_id: Annotated[
+        str | None,
+        Query(
+            ...,
+            alias="dataset_id",
+            description="The ID of the dataset",
+        ),
+    ] = None,
+    valid: Annotated[
+        bool | None,
+        Query(
+            ...,
+            alias="valid",
+            description="Whether the grant is currently valid",
+        ),
+    ] = None,
+    # internal service, authorization without token via service mesh
+) -> list[Grant]:
+    """Get access grants.
+
+    You can filter the grants by user ID, IVA ID, and dataset ID
+    and by whether the grant is currently valid or not.
+    """
+    # Determine all controlled access grants for the user
+    grants: list[Grant] = []
+    users: dict[str, User | None] = {}  # user cache
+    mapping = create_controlled_access_filter(
+        user_id=user_id, iva_id=iva_id, dataset_id=dataset_id
+    )
+    async for claim in claim_dao.find_all(mapping=mapping):
+        if claim.revocation_date:
+            continue  # revoked claims should be considered deleted as grants
+        if valid is not None and is_valid_claim(claim) != valid:
+            continue  # filter by validity if requested
+        dataset_id = dataset_id_for_download_access(claim)
+        if not dataset_id:
+            continue  # consider only claims for the right source
+        # find user name and email
+        user_id = claim.user_id
+        try:
+            user = users[user_id]
+        except KeyError:
+            try:
+                user = await user_dao.get_by_id(user_id)
+            except ResourceNotFoundError:
+                user = None
+            users[user_id] = user
+        if not user:
+            continue
+        grants.append(
+            Grant(
+                id=claim.id,
+                user_id=user_id,
+                iva_id=claim.iva_id,
+                dataset_id=dataset_id,
+                created=claim.creation_date,
+                valid_from=claim.valid_from,
+                valid_until=claim.valid_until,
+                user_name=user.name,
+                user_email=user.email,
+                user_title=user.title,
+            )
+        )
+    # sort the output by ID to make it reproducible
+    return sorted(grants, key=attrgetter("id"))
 
 
 @start_span()
@@ -180,12 +285,8 @@ async def check_download_access(
 
     valid_until: UTCDatetime | None = None
     # run through all controlled access grants for the user
-    async for claim in claim_dao.find_all(
-        mapping={
-            "user_id": user_id,
-            "visa_type": VisaType.CONTROLLED_ACCESS_GRANTS,
-        }
-    ):
+    mapping = create_controlled_access_filter(user_id=user_id)
+    async for claim in claim_dao.find_all(mapping=mapping):
         # check whether the claim is valid and for the right source
         if not (
             is_valid_claim(claim)
@@ -247,13 +348,9 @@ async def get_datasets_with_download_access(
         raise user_not_found_error
 
     dataset_id_to_end_date: dict[str, UTCDatetime] = {}
+    mapping = create_controlled_access_filter(user_id=user_id)
     # run through all controlled access grants for the user
-    async for claim in claim_dao.find_all(
-        mapping={
-            "user_id": user_id,
-            "visa_type": VisaType.CONTROLLED_ACCESS_GRANTS,
-        }
-    ):
+    async for claim in claim_dao.find_all(mapping=mapping):
         # consider only valid controlled access grants for the user
         if not (
             is_valid_claim(claim)

--- a/tests/integration/claims_repository/test_access_api.py
+++ b/tests/integration/claims_repository/test_access_api.py
@@ -13,16 +13,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Test the REST API"""
+"""Test the access grant REST API"""
 
 from datetime import datetime
-from operator import itemgetter
 from typing import Any
 
 import pytest
 from fastapi import status
 from ghga_service_commons.utils.utc_dates import now_as_utc
 
+from auth_service.claims_repository.deps import get_claim_dao
 from auth_service.user_registry.deps import get_iva_dao, get_user_dao
 from auth_service.user_registry.models.ivas import (
     Iva,
@@ -31,258 +31,11 @@ from auth_service.user_registry.models.ivas import (
 )
 from auth_service.user_registry.models.users import UserStatus
 
-from ...fixtures.utils import DummyIvaDao, DummyUserDao
+from ...fixtures.utils import DummyClaimDao, DummyIvaDao, DummyUserDao
 from .fixtures import FullClient, fixture_full_client  # noqa: F401
+from .test_claims_api import DATASET_CLAIM_DATA
 
 pytestmark = pytest.mark.asyncio()
-
-ROLE_CLAIM_DATA = {
-    "visa_type": "https://www.ghga.de/GA4GH/VisaTypes/Role/v1.0",
-    "visa_value": "data_steward@ghga.de",
-    "valid_from": "2022-10-01T12:00:00Z",
-    "valid_until": "2022-10-31T12:00:00Z",
-    "assertion_date": "2022-09-01T12:00:00Z",
-    "source": "https://ghga.de",
-    "asserted_by": "system",
-}
-
-DATASET_CLAIM_DATA = {
-    "visa_type": "ControlledAccessGrants",
-    "visa_value": "https://ghga.de/datasets/DS0815",
-    "assertion_date": "2022-06-01T12:00:00Z",
-    "source": "https://ghga.de",
-    "asserted_by": "system",
-}
-
-
-async def test_health_check(full_client: FullClient):
-    """Test that the health check endpoint works."""
-    response = await full_client.get("/health")
-
-    assert response.status_code == status.HTTP_200_OK
-    assert response.json() == {"status": "OK"}
-
-
-async def test_get_from_a_random_path(full_client: FullClient):
-    """Test that a GET request to a random path raises a not found error."""
-    response = await full_client.post("/some/random/path")
-
-    assert response.status_code == status.HTTP_404_NOT_FOUND
-
-
-async def test_post_claim(full_client: FullClient):
-    """Test that creating a user claim works."""
-    user_dao = DummyUserDao()
-    full_client.app.dependency_overrides[get_user_dao] = lambda: user_dao
-
-    response = await full_client.post(
-        "/users/john@ghga.de/claims", json=ROLE_CLAIM_DATA
-    )
-
-    claim = response.json()
-    assert response.status_code == status.HTTP_201_CREATED, claim
-
-    claim_id = claim.pop("id", None)
-    assert claim_id is not None
-    assert len(claim_id) == 36
-    assert claim_id.count("-") == 4
-    assert claim.pop("user_id") == "john@ghga.de"
-    assert claim.pop("iva_id") is None
-    assert claim.pop("sub_source") is None
-
-    assert claim.pop("conditions") is None
-    assert claim.pop("revocation_date") is None
-    assert claim.pop("creation_date") is not None
-
-    assert claim == ROLE_CLAIM_DATA
-
-    # test with non-existing user
-    response = await full_client.post(
-        "/users/john@haag.de/claims", json=ROLE_CLAIM_DATA
-    )
-    assert response.status_code == status.HTTP_404_NOT_FOUND
-    assert response.json()["detail"] == "The user was not found."
-
-
-async def test_get_claims(full_client: FullClient):
-    """Test that getting all claims of a user works."""
-    user_dao = DummyUserDao()
-    full_client.app.dependency_overrides[get_user_dao] = lambda: user_dao
-
-    user_id = "john@ghga.de"
-
-    # post two different claims
-    claim1 = ROLE_CLAIM_DATA
-    claim2 = {
-        **claim1,
-        "assertion_date": "2022-09-01T13:00:00Z",
-        "visa_type": "ResearcherStatus",
-        "visa_value": "researcher@ghga.de",
-    }
-    posted_claims = []
-    for claim in (claim1, claim2):
-        response = await full_client.post(f"/users/{user_id}/claims", json=claim)
-        assert response.status_code == status.HTTP_201_CREATED
-        posted_claims.append(response.json())
-
-    response = await full_client.get(f"/users/{user_id}/claims")
-    assert response.status_code == status.HTTP_200_OK
-    requested_claims = response.json()
-    requested_claims.sort(key=itemgetter("assertion_date"))
-
-    assert requested_claims == posted_claims
-
-    assert requested_claims[0]["user_id"] == user_id
-    assert requested_claims[1]["user_id"] == user_id
-    assert requested_claims[0]["visa_type"] == ROLE_CLAIM_DATA["visa_type"]
-    assert requested_claims[1]["visa_type"] == "ResearcherStatus"
-    assert requested_claims[0]["visa_value"] != requested_claims[1]["visa_value"]
-
-    # test with non-existing user
-    response = await full_client.get("/users/john@haag.de/claims")
-    assert response.status_code == status.HTTP_404_NOT_FOUND
-    assert response.json()["detail"] == "The user was not found."
-
-
-async def test_patch_claim(full_client: FullClient):
-    """Test that revoking a user claim works."""
-    user_dao = DummyUserDao()
-    full_client.app.dependency_overrides[get_user_dao] = lambda: user_dao
-
-    user_id = "john@ghga.de"
-
-    # post test claim
-    response = await full_client.post(f"/users/{user_id}/claims", json=ROLE_CLAIM_DATA)
-    posted_claim = response.json()
-    assert response.status_code == status.HTTP_201_CREATED
-
-    claim_id = posted_claim["id"]
-    assert claim_id is not None
-    assert posted_claim.pop("revocation_date") is None
-
-    # revoke test claim
-    revocation_date = "2022-10-15T12:00:00Z"
-    patch_data = {"revocation_date": revocation_date}
-    response = await full_client.patch(
-        f"/users/{user_id}/claims/{claim_id}", json=patch_data
-    )
-    assert response.status_code == status.HTTP_204_NO_CONTENT
-
-    # test that claim has been revoked
-    response = await full_client.get(f"/users/{user_id}/claims")
-    assert response.status_code == status.HTTP_200_OK
-    claims = response.json()
-    assert len(claims) == 1
-    claim = claims[0]
-    assert claim.pop("revocation_date") == revocation_date
-    assert claim == posted_claim
-
-    # test without revocation date
-    patch_data = {"revocation_date": None}  # type: ignore
-    response = await full_client.patch(
-        f"/users/{user_id}/claims/{claim_id}", json=patch_data
-    )
-    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
-
-    # test with later revocation date
-    patch_data = {"revocation_date": "2022-10-15T13:00:00Z"}
-    response = await full_client.patch(
-        f"/users/{user_id}/claims/{claim_id}", json=patch_data
-    )
-    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
-    assert response.json()["detail"] == "Already revoked earlier."
-
-    # test with earlier revocation date
-    revocation_date = "2022-10-15T11:00:00Z"
-    patch_data = {"revocation_date": revocation_date}
-    response = await full_client.patch(
-        f"/users/{user_id}/claims/{claim_id}", json=patch_data
-    )
-    assert response.status_code == status.HTTP_204_NO_CONTENT
-
-    # test that revocation was advanced
-    response = await full_client.get(f"/users/{user_id}/claims")
-    assert response.status_code == status.HTTP_200_OK
-    claims = response.json()
-    assert len(claims) == 1
-    claim = claims[0]
-    assert claim.pop("revocation_date") == revocation_date
-    assert claim == posted_claim
-
-    # test with non-existing user
-    response = await full_client.patch(
-        f"/users/john@haag.de/claims/{claim_id}", json=patch_data
-    )
-    assert response.status_code == status.HTTP_404_NOT_FOUND
-    assert response.json()["detail"] == "The user was not found."
-    # test with non-existing claim
-    response = await full_client.patch(
-        f"/users/{user_id}/claims/invalid-claim-id", json=patch_data
-    )
-    assert response.status_code == status.HTTP_404_NOT_FOUND
-    assert response.json()["detail"] == "The user claim was not found."
-
-
-async def test_delete_claim(full_client: FullClient):
-    """Test that deleting a user claim works."""
-    user_dao = DummyUserDao()
-    full_client.app.dependency_overrides[get_user_dao] = lambda: user_dao
-
-    user_id = "john@ghga.de"
-
-    # post two different claims
-    claim1 = ROLE_CLAIM_DATA.copy()
-    claim2 = ROLE_CLAIM_DATA.copy()
-    claim2["visa_type"] = "ResearcherStatus"
-    for claim in (claim1, claim2):
-        response = await full_client.post(f"/users/{user_id}/claims", json=claim)
-        assert response.status_code == status.HTTP_201_CREATED
-        claim_id = response.json()["id"]
-        assert claim_id
-        claim["id"] = claim_id
-
-    # test deletion of first claim with non-existing user
-    claim_id = claim1["id"]
-    response = await full_client.delete(f"/users/john@haag.de/claims/{claim_id}")
-    assert response.status_code == status.HTTP_404_NOT_FOUND
-
-    # test that claims have been posted
-    response = await full_client.get(f"/users/{user_id}/claims")
-    assert response.status_code == status.HTTP_200_OK
-    claims = response.json()
-    assert len(claims) == 2
-
-    # delete first claim properly
-    response = await full_client.delete(f"/users/{user_id}/claims/{claim_id}")
-    assert response.status_code == status.HTTP_204_NO_CONTENT
-
-    # test that claim has been deleted
-    response = await full_client.get(f"/users/{user_id}/claims")
-    assert response.status_code == status.HTTP_200_OK
-    claims = response.json()
-    assert len(claims) == 1
-    claim = claims[0]
-    assert claim["id"] == claim2["id"]
-    assert claim["visa_type"] == "ResearcherStatus"
-
-    # delete again
-    response = await full_client.delete(f"/users/{user_id}/claims/{claim_id}")
-    assert response.status_code == status.HTTP_404_NOT_FOUND
-
-    # delete second claim
-    claim_id = claim2["id"]
-    response = await full_client.delete(f"/users/{user_id}/claims/{claim_id}")
-    assert response.status_code == status.HTTP_204_NO_CONTENT
-
-    # test that claim has been deleted
-    response = await full_client.get(f"/users/{user_id}/claims")
-    assert response.status_code == status.HTTP_200_OK
-    claims = response.json()
-    assert len(claims) == 0
-
-    # delete again
-    response = await full_client.delete(f"/users/{user_id}/claims/{claim_id}")
-    assert response.status_code == status.HTTP_404_NOT_FOUND
 
 
 async def test_grant_download_access(full_client: FullClient):
@@ -806,27 +559,77 @@ async def test_get_datasets_with_download_access(full_client: FullClient):
     assert response.json()["detail"] == "The user was not found."
 
 
-async def test_get_claims_for_seeded_data_steward(full_client: FullClient):
-    """Test that the database is seeded with the configured data steward."""
-    response = await full_client.get("/users/the-id-of-rod-steward/claims")
-    assert response.status_code == status.HTTP_200_OK
-    claims = response.json()
-    assert len(claims) == 1
-    claim = claims[0]
+async def test_getting_all_access_grants(full_client: FullClient):
+    """Test that getting all access grants works."""
+    user_dao = DummyUserDao(title="Prof.", name="John Doe Sr.")
+    full_client.app.dependency_overrides[get_user_dao] = lambda: user_dao
+    claim_dao = DummyClaimDao()
+    full_client.app.dependency_overrides[get_claim_dao] = lambda: claim_dao
+    user = user_dao.users[0]
+    assert user.name == "John Doe Sr."
+    claim = claim_dao.claims[1]
+    assert claim.visa_type == "ControlledAccessGrants"
+    assert claim.user_id == user.id
+    dt_to_str = lambda dt: dt.isoformat().replace("+00:00", "Z")
+    expected_grants = [
+        {
+            "created": dt_to_str(claim.creation_date),
+            "dataset_id": "DS0815",
+            "id": "data-access-claim-id",
+            "iva_id": "data-access-iva-id",
+            "user_email": "john@home.org",
+            "user_id": "john@ghga.de",
+            "user_name": "John Doe Sr.",
+            "user_title": "Prof.",
+            "valid_from": dt_to_str(claim.valid_from),
+            "valid_until": dt_to_str(claim.valid_until),
+        },
+    ]
 
-    assert claim.pop("id")
-    assert claim.pop("iva_id")
-    assertion_date = claim.pop("assertion_date")
-    assert claim.pop("creation_date") == assertion_date
-    assert claim.pop("valid_from") == assertion_date
-    assert claim.pop("valid_until") > assertion_date
-    assert claim == {
-        "asserted_by": "system",
-        "conditions": None,
-        "revocation_date": None,
-        "user_id": "the-id-of-rod-steward",
-        "source": "https://ghga.de",
-        "sub_source": None,
-        "visa_type": "https://www.ghga.de/GA4GH/VisaTypes/Role/v1.0",
-        "visa_value": "data_steward@ghga.de",
-    }
+    response = await full_client.get("/download-access/grants")
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json() == expected_grants
+
+    # check filtering for the user ID
+    response = await full_client.get("/download-access/grants?user_id=jack@ghga.de")
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json() == []
+    response = await full_client.get("/download-access/grants?user_id=invalid-email")
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json() == []
+    response = await full_client.get("/download-access/grants?user_id=john@ghga.de")
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json() == expected_grants
+
+    # check filtering for the IVA ID
+    response = await full_client.get(
+        "/download-access/grants?iva_id=no-data-access-iva-id"
+    )
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json() == []
+    response = await full_client.get(
+        "/download-access/grants?iva_id=data-access-iva-id"
+    )
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json() == expected_grants
+
+    # check filtering for the dataset ID
+    response = await full_client.get("/download-access/grants?dataset_id=DS0917")
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json() == []
+    response = await full_client.get(
+        "/download-access/grants?dataset_id=invalid-accession"
+    )
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json() == []
+    response = await full_client.get("/download-access/grants?dataset_id=DS0815")
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json() == expected_grants
+
+    # check filtering for the validity
+    response = await full_client.get("/download-access/grants?valid=false")
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json() == []
+    response = await full_client.get("/download-access/grants?valid=true")
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json() == expected_grants

--- a/tests/integration/claims_repository/test_claims_api.py
+++ b/tests/integration/claims_repository/test_claims_api.py
@@ -1,0 +1,302 @@
+# Copyright 2021 - 2025 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Test the core claims REST API"""
+
+from operator import itemgetter
+
+import pytest
+from fastapi import status
+
+from auth_service.user_registry.deps import get_user_dao
+
+from ...fixtures.utils import DummyUserDao
+from .fixtures import FullClient, fixture_full_client  # noqa: F401
+
+pytestmark = pytest.mark.asyncio()
+
+ROLE_CLAIM_DATA = {
+    "visa_type": "https://www.ghga.de/GA4GH/VisaTypes/Role/v1.0",
+    "visa_value": "data_steward@ghga.de",
+    "valid_from": "2022-10-01T12:00:00Z",
+    "valid_until": "2022-10-31T12:00:00Z",
+    "assertion_date": "2022-09-01T12:00:00Z",
+    "source": "https://ghga.de",
+    "asserted_by": "system",
+}
+
+DATASET_CLAIM_DATA = {
+    "visa_type": "ControlledAccessGrants",
+    "visa_value": "https://ghga.de/datasets/DS0815",
+    "assertion_date": "2022-06-01T12:00:00Z",
+    "source": "https://ghga.de",
+    "asserted_by": "system",
+}
+
+
+async def test_health_check(full_client: FullClient):
+    """Test that the health check endpoint works."""
+    response = await full_client.get("/health")
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json() == {"status": "OK"}
+
+
+async def test_get_from_a_random_path(full_client: FullClient):
+    """Test that a GET request to a random path raises a not found error."""
+    response = await full_client.post("/some/random/path")
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+async def test_post_claim(full_client: FullClient):
+    """Test that creating a user claim works."""
+    user_dao = DummyUserDao()
+    full_client.app.dependency_overrides[get_user_dao] = lambda: user_dao
+
+    response = await full_client.post(
+        "/users/john@ghga.de/claims", json=ROLE_CLAIM_DATA
+    )
+
+    claim = response.json()
+    assert response.status_code == status.HTTP_201_CREATED, claim
+
+    claim_id = claim.pop("id", None)
+    assert claim_id is not None
+    assert len(claim_id) == 36
+    assert claim_id.count("-") == 4
+    assert claim.pop("user_id") == "john@ghga.de"
+    assert claim.pop("iva_id") is None
+    assert claim.pop("sub_source") is None
+
+    assert claim.pop("conditions") is None
+    assert claim.pop("revocation_date") is None
+    assert claim.pop("creation_date") is not None
+
+    assert claim == ROLE_CLAIM_DATA
+
+    # test with non-existing user
+    response = await full_client.post(
+        "/users/john@haag.de/claims", json=ROLE_CLAIM_DATA
+    )
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+    assert response.json()["detail"] == "The user was not found."
+
+
+async def test_get_claims(full_client: FullClient):
+    """Test that getting all claims of a user works."""
+    user_dao = DummyUserDao()
+    full_client.app.dependency_overrides[get_user_dao] = lambda: user_dao
+
+    user_id = "john@ghga.de"
+
+    # post two different claims
+    claim1 = ROLE_CLAIM_DATA
+    claim2 = {
+        **claim1,
+        "assertion_date": "2022-09-01T13:00:00Z",
+        "visa_type": "ResearcherStatus",
+        "visa_value": "researcher@ghga.de",
+    }
+    posted_claims = []
+    for claim in (claim1, claim2):
+        response = await full_client.post(f"/users/{user_id}/claims", json=claim)
+        assert response.status_code == status.HTTP_201_CREATED
+        posted_claims.append(response.json())
+
+    response = await full_client.get(f"/users/{user_id}/claims")
+    assert response.status_code == status.HTTP_200_OK
+    requested_claims = response.json()
+    requested_claims.sort(key=itemgetter("assertion_date"))
+
+    assert requested_claims == posted_claims
+
+    assert requested_claims[0]["user_id"] == user_id
+    assert requested_claims[1]["user_id"] == user_id
+    assert requested_claims[0]["visa_type"] == ROLE_CLAIM_DATA["visa_type"]
+    assert requested_claims[1]["visa_type"] == "ResearcherStatus"
+    assert requested_claims[0]["visa_value"] != requested_claims[1]["visa_value"]
+
+    # test with non-existing user
+    response = await full_client.get("/users/john@haag.de/claims")
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+    assert response.json()["detail"] == "The user was not found."
+
+
+async def test_patch_claim(full_client: FullClient):
+    """Test that revoking a user claim works."""
+    user_dao = DummyUserDao()
+    full_client.app.dependency_overrides[get_user_dao] = lambda: user_dao
+
+    user_id = "john@ghga.de"
+
+    # post test claim
+    response = await full_client.post(f"/users/{user_id}/claims", json=ROLE_CLAIM_DATA)
+    posted_claim = response.json()
+    assert response.status_code == status.HTTP_201_CREATED
+
+    claim_id = posted_claim["id"]
+    assert claim_id is not None
+    assert posted_claim.pop("revocation_date") is None
+
+    # revoke test claim
+    revocation_date = "2022-10-15T12:00:00Z"
+    patch_data = {"revocation_date": revocation_date}
+    response = await full_client.patch(
+        f"/users/{user_id}/claims/{claim_id}", json=patch_data
+    )
+    assert response.status_code == status.HTTP_204_NO_CONTENT
+
+    # test that claim has been revoked
+    response = await full_client.get(f"/users/{user_id}/claims")
+    assert response.status_code == status.HTTP_200_OK
+    claims = response.json()
+    assert len(claims) == 1
+    claim = claims[0]
+    assert claim.pop("revocation_date") == revocation_date
+    assert claim == posted_claim
+
+    # test without revocation date
+    patch_data = {"revocation_date": None}  # type: ignore
+    response = await full_client.patch(
+        f"/users/{user_id}/claims/{claim_id}", json=patch_data
+    )
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+    # test with later revocation date
+    patch_data = {"revocation_date": "2022-10-15T13:00:00Z"}
+    response = await full_client.patch(
+        f"/users/{user_id}/claims/{claim_id}", json=patch_data
+    )
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    assert response.json()["detail"] == "Already revoked earlier."
+
+    # test with earlier revocation date
+    revocation_date = "2022-10-15T11:00:00Z"
+    patch_data = {"revocation_date": revocation_date}
+    response = await full_client.patch(
+        f"/users/{user_id}/claims/{claim_id}", json=patch_data
+    )
+    assert response.status_code == status.HTTP_204_NO_CONTENT
+
+    # test that revocation was advanced
+    response = await full_client.get(f"/users/{user_id}/claims")
+    assert response.status_code == status.HTTP_200_OK
+    claims = response.json()
+    assert len(claims) == 1
+    claim = claims[0]
+    assert claim.pop("revocation_date") == revocation_date
+    assert claim == posted_claim
+
+    # test with non-existing user
+    response = await full_client.patch(
+        f"/users/john@haag.de/claims/{claim_id}", json=patch_data
+    )
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+    assert response.json()["detail"] == "The user was not found."
+    # test with non-existing claim
+    response = await full_client.patch(
+        f"/users/{user_id}/claims/invalid-claim-id", json=patch_data
+    )
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+    assert response.json()["detail"] == "The user claim was not found."
+
+
+async def test_delete_claim(full_client: FullClient):
+    """Test that deleting a user claim works."""
+    user_dao = DummyUserDao()
+    full_client.app.dependency_overrides[get_user_dao] = lambda: user_dao
+
+    user_id = "john@ghga.de"
+
+    # post two different claims
+    claim1 = ROLE_CLAIM_DATA.copy()
+    claim2 = ROLE_CLAIM_DATA.copy()
+    claim2["visa_type"] = "ResearcherStatus"
+    for claim in (claim1, claim2):
+        response = await full_client.post(f"/users/{user_id}/claims", json=claim)
+        assert response.status_code == status.HTTP_201_CREATED
+        claim_id = response.json()["id"]
+        assert claim_id
+        claim["id"] = claim_id
+
+    # test deletion of first claim with non-existing user
+    claim_id = claim1["id"]
+    response = await full_client.delete(f"/users/john@haag.de/claims/{claim_id}")
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    # test that claims have been posted
+    response = await full_client.get(f"/users/{user_id}/claims")
+    assert response.status_code == status.HTTP_200_OK
+    claims = response.json()
+    assert len(claims) == 2
+
+    # delete first claim properly
+    response = await full_client.delete(f"/users/{user_id}/claims/{claim_id}")
+    assert response.status_code == status.HTTP_204_NO_CONTENT
+
+    # test that claim has been deleted
+    response = await full_client.get(f"/users/{user_id}/claims")
+    assert response.status_code == status.HTTP_200_OK
+    claims = response.json()
+    assert len(claims) == 1
+    claim = claims[0]
+    assert claim["id"] == claim2["id"]
+    assert claim["visa_type"] == "ResearcherStatus"
+
+    # delete again
+    response = await full_client.delete(f"/users/{user_id}/claims/{claim_id}")
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    # delete second claim
+    claim_id = claim2["id"]
+    response = await full_client.delete(f"/users/{user_id}/claims/{claim_id}")
+    assert response.status_code == status.HTTP_204_NO_CONTENT
+
+    # test that claim has been deleted
+    response = await full_client.get(f"/users/{user_id}/claims")
+    assert response.status_code == status.HTTP_200_OK
+    claims = response.json()
+    assert len(claims) == 0
+
+    # delete again
+    response = await full_client.delete(f"/users/{user_id}/claims/{claim_id}")
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+async def test_get_claims_for_seeded_data_steward(full_client: FullClient):
+    """Test that the database is seeded with the configured data steward."""
+    response = await full_client.get("/users/the-id-of-rod-steward/claims")
+    assert response.status_code == status.HTTP_200_OK
+    claims = response.json()
+    assert len(claims) == 1
+    claim = claims[0]
+
+    assert claim.pop("id")
+    assert claim.pop("iva_id")
+    assertion_date = claim.pop("assertion_date")
+    assert claim.pop("creation_date") == assertion_date
+    assert claim.pop("valid_from") == assertion_date
+    assert claim.pop("valid_until") > assertion_date
+    assert claim == {
+        "asserted_by": "system",
+        "conditions": None,
+        "revocation_date": None,
+        "user_id": "the-id-of-rod-steward",
+        "source": "https://ghga.de",
+        "sub_source": None,
+        "visa_type": "https://www.ghga.de/GA4GH/VisaTypes/Role/v1.0",
+        "visa_value": "data_steward@ghga.de",
+    }

--- a/tests/integration/claims_repository/test_seed.py
+++ b/tests/integration/claims_repository/test_seed.py
@@ -131,7 +131,7 @@ async def test_add_data_steward(
     assert iva["verification_code_hash"] is None
     creation_date = iva["created"]
     time_diff = now_as_utc() - datetime.fromisoformat(creation_date)
-    assert -1 < time_diff.total_seconds() < 3
+    assert -1 < time_diff.total_seconds() < 5
     assert iva["changed"] == iva["created"]
 
     claims_collection = db.get_collection(config.claims_collection)
@@ -148,7 +148,7 @@ async def test_add_data_steward(
     assert claim["conditions"] is None
     creation_date = claim["creation_date"]
     time_diff = now_as_utc() - datetime.fromisoformat(creation_date)
-    assert -1 < time_diff.total_seconds() < 3
+    assert -1 < time_diff.total_seconds() < 5
     assert claim["assertion_date"] == creation_date
     assert claim["valid_from"] == creation_date
     assert (
@@ -191,7 +191,7 @@ async def test_add_data_steward(
         time_diff = datetime.fromisoformat(
             new_claim.pop(date_field)
         ) - datetime.fromisoformat(claim.pop(date_field))
-        assert -1 < time_diff.total_seconds() < 3
+        assert -1 < time_diff.total_seconds() < 5
     assert new_claim == claim
 
     # add data steward with different name


### PR DESCRIPTION
This PR adds two endpoints to the access API of the claims repository, as specified in the Royal Angelfish epic.

Unfortunately, the claims repository has much of the domain logic directly inside the router modules. This should eventually be refactored and cleanly separated, but let's keept it like that for now.