### PR TITLE
Support for user manager (GSI-1770)

### DIFF
--- a/src/auth_service/auth_adapter/prepare.py
+++ b/src/auth_service/auth_adapter/prepare.py
@@ -80,6 +80,7 @@ async def prepare_rest_app(config: Config) -> AsyncGenerator[FastAPI, None]:
             config=config,
             user_dao=user_dao,
             iva_dao=iva_dao,
+            claim_dao=claim_dao,
             event_pub=event_pub,
         )
 

--- a/src/auth_service/config.py
+++ b/src/auth_service/config.py
@@ -36,7 +36,7 @@ from auth_service.claims_repository.translators.dao import (
 from auth_service.claims_repository.translators.event_sub import (
     EventSubTranslatorConfig,
 )
-from auth_service.user_registry.core.registry import UserRegistryConfig
+from auth_service.user_registry.core.config import UserRegistryConfig
 from auth_service.user_registry.translators.dao import UserDaoConfig
 from auth_service.user_registry.translators.event_pub import (
     EventPubTranslatorConfig,

--- a/src/auth_service/prepare.py
+++ b/src/auth_service/prepare.py
@@ -153,6 +153,7 @@ async def prepare_rest_app(config: Config) -> AsyncGenerator[FastAPI, None]:
                 config=config,
                 user_dao=user_dao,
                 iva_dao=iva_dao,
+                claim_dao=claim_dao,
                 event_pub=event_pub,
             )
             app.dependency_overrides[get_user_registry] = lambda: user_registry

--- a/src/auth_service/user_registry/core/config.py
+++ b/src/auth_service/user_registry/core/config.py
@@ -1,0 +1,35 @@
+# Copyright 2021 - 2025 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Configuration of the core user registry."""
+
+from __future__ import annotations
+
+from pydantic import Field
+from pydantic_settings import BaseSettings
+
+from ..models.users import UserStatus
+
+INITIAL_USER_STATUS = UserStatus.ACTIVE
+
+__all__ = ["INITIAL_USER_STATUS", "UserRegistryConfig"]
+
+
+class UserRegistryConfig(BaseSettings):
+    """Configuration for the user registry."""
+
+    max_iva_verification_attempts: int = Field(
+        default=10, description="Maximum number of verification attempts for an IVA"
+    )

--- a/src/auth_service/user_registry/models/users.py
+++ b/src/auth_service/user_registry/models/users.py
@@ -23,7 +23,7 @@ from pydantic import EmailStr, Field
 
 from . import BaseDto
 
-__all__ = ["StatusChange", "User", "UserData", "UserStatus"]
+__all__ = ["StatusChange", "User", "UserData", "UserStatus", "UserWithRoles"]
 
 
 class UserStatus(StrEnum):
@@ -131,4 +131,14 @@ class User(UserData):
 
     id: str = Field(
         default_factory=lambda: str(uuid4()), description="Internal user ID"
+    )
+
+
+class UserWithRoles(User):
+    """Complete User model plus roles"""
+
+    roles: list[str] = Field(
+        default=[],
+        description="List of roles assigned to the user",
+        examples=["data_steward", "data_provider"],
     )

--- a/src/auth_service/user_registry/ports/registry.py
+++ b/src/auth_service/user_registry/ports/registry.py
@@ -21,7 +21,13 @@ from abc import ABC, abstractmethod
 from typing import Any
 
 from ..models.ivas import Iva, IvaAndUserData, IvaBasicData, IvaData, IvaState
-from ..models.users import User, UserBasicData, UserModifiableData, UserRegisteredData
+from ..models.users import (
+    User,
+    UserBasicData,
+    UserModifiableData,
+    UserRegisteredData,
+    UserWithRoles,
+)
 
 
 class UserRegistryPort(ABC):
@@ -173,6 +179,16 @@ class UserRegistryPort(ABC):
         ...
 
     @abstractmethod
+    async def get_user_with_roles(self, user_id: str) -> UserWithRoles:
+        """Get user data including all roles, independent of IVAs.
+
+        The roles are returned even if the user is inactive or has no IVAs.
+
+        May raise a UserDoesNotExistError or a UserRetrievalError.
+        """
+        ...
+
+    @abstractmethod
     async def update_user(
         self,
         user_id: str,
@@ -192,6 +208,8 @@ class UserRegistryPort(ABC):
     @abstractmethod
     async def delete_user(self, user_id: str) -> None:
         """Delete a user.
+
+        This also deletes all IVAs and claims belonging to the user.
 
         May raise a UserDoesNotExistError or a UserDeletionError.
         """

--- a/src/auth_service/user_registry/ports/registry.py
+++ b/src/auth_service/user_registry/ports/registry.py
@@ -26,6 +26,7 @@ from ..models.users import (
     UserBasicData,
     UserModifiableData,
     UserRegisteredData,
+    UserStatus,
     UserWithRoles,
 )
 
@@ -52,10 +53,14 @@ class UserRegistryPort(ABC):
             super().__init__(ext_id=ext_id, details="user already exists")
 
     class UserRetrievalError(UserRegistryError):
-        """Raised when a user cannot be retrieved from the database."""
+        """Raised when users cannot be retrieved from the database."""
 
-        def __init__(self, *, user_id: str):
-            message = f"Could not retrieve user with ID {user_id}"
+        def __init__(self, *, user_id: str | None = None):
+            message = (
+                f"Could not retrieve user with ID {user_id}"
+                if user_id
+                else "Could not retrieve users"
+            )
             super().__init__(message)
 
     class UserDoesNotExistError(UserRegistryError):
@@ -185,6 +190,30 @@ class UserRegistryPort(ABC):
         The roles are returned even if the user is inactive or has no IVAs.
 
         May raise a UserDoesNotExistError or a UserRetrievalError.
+        """
+        ...
+
+    @abstractmethod
+    async def get_users(self, status: UserStatus | None = None) -> list[User]:
+        """Get all users.
+
+        The users can be filtered by a given status.
+
+        May raise a UserRetrievalError.
+        """
+        ...
+
+    @abstractmethod
+    async def get_users_with_roles(
+        self, status: UserStatus | None = None
+    ) -> list[UserWithRoles]:
+        """Get all users with their roles.
+
+        The users can be filtered by a given status.
+
+        The roles are returned even if the users are inactive or have no IVAs.
+
+        May raise a UserRetrievalError.
         """
         ...
 

--- a/tests/fixtures/utils.py
+++ b/tests/fixtures/utils.py
@@ -476,9 +476,14 @@ class DummyClaimDao:
         for claim in self.claims:
             data = claim.model_dump()
             data["id_"] = data.pop("id")
-            for key in mapping:
-                if mapping[key] != data[key]:
+            for key, value in mapping.items():
+                if isinstance(value, dict) and "$in" in value:
+                    value = value["$in"]
+                    if data[key] not in value:
+                        break
+                elif data[key] != value:
                     break
+
             else:
                 yield claim
 

--- a/tests/fixtures/utils.py
+++ b/tests/fixtures/utils.py
@@ -27,6 +27,7 @@ from ghga_service_commons.api import ApiConfigBase
 from ghga_service_commons.utils.utc_dates import UTCDatetime, now_as_utc, utc_datetime
 from hexkit.config import config_from_yaml
 from hexkit.protocols.dao import (
+    Dao,
     MultipleHitsFoundError,
     NoHitsFoundError,
     ResourceNotFoundError,
@@ -42,6 +43,7 @@ from auth_service.claims_repository.models.claims import (
 )
 from auth_service.config import CONFIG
 from auth_service.user_registry.core.registry import (
+    ClaimDto,
     DaoPublisher,
     IvaDto,
     UserDto,
@@ -529,11 +531,13 @@ class DummyUserRegistry(UserRegistry):
         """Initialize the DummyUserRegistry."""
         self.dummy_user_dao = DummyUserDao()
         self.dummy_iva_dao = DummyIvaDao([])
+        self._dummy_claim_dao = DummyClaimDao()
         event_publisher = DummyEventPublisher()
         super().__init__(
             config=config,
             user_dao=cast(DaoPublisher[UserDto], self.dummy_user_dao),
             iva_dao=cast(DaoPublisher[IvaDto], self.dummy_iva_dao),
+            claim_dao=cast(Dao[ClaimDto], self._dummy_claim_dao),
             event_pub=event_publisher,
         )
         self.published_events = event_publisher.published_events


### PR DESCRIPTION
This PR adds an endpoint to get the list of users, filtered by status.

It also augments the user data with the current roles, taken from the claims repository.

The existing endpoint to get an individual user now also returns the current roles of the user.