### PR TITLE
Patch v2 migration for deleted outbox docs

### DIFF
--- a/.pyproject_generation/pyproject_custom.toml
+++ b/.pyproject_generation/pyproject_custom.toml
@@ -1,6 +1,6 @@
 [project]
 name = "auth_service"
-version = "8.0.0"
+version = "8.0.1"
 description = "Authentication adapter and services used for the GHGA data portal"
 dependencies = [
     "ghga-event-schemas~=10.0.0",

--- a/README.md
+++ b/README.md
@@ -47,13 +47,13 @@ We recommend using the provided Docker container.
 
 A pre-built version is available at [docker hub](https://hub.docker.com/repository/docker/ghga/auth-service):
 ```bash
-docker pull ghga/auth-service:8.0.0
+docker pull ghga/auth-service:8.0.1
 ```
 
 Or you can build the container yourself from the [`./Dockerfile`](./Dockerfile):
 ```bash
 # Execute in the repo's root dir:
-docker build -t ghga/auth-service:8.0.0 .
+docker build -t ghga/auth-service:8.0.1 .
 ```
 
 For production-ready deployment, we recommend using Kubernetes, however,
@@ -61,7 +61,7 @@ for simple use cases, you could execute the service using docker
 on a single server:
 ```bash
 # The entrypoint is preconfigured:
-docker run -p 8080:8080 ghga/auth-service:8.0.0 --help
+docker run -p 8080:8080 ghga/auth-service:8.0.1 --help
 ```
 
 If you prefer not to use containers, you may install the service from source:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -909,7 +909,7 @@ info:
   license:
     name: Apache 2.0
   title: Auth Service API
-  version: 8.0.0
+  version: 8.0.1
 openapi: 3.1.0
 paths:
   /download-access/grants:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Intended Audience :: Developers",
 ]
 name = "auth_service"
-version = "8.0.0"
+version = "8.0.1"
 description = "Authentication adapter and services used for the GHGA data portal"
 dependencies = [
     "ghga-event-schemas~=10.0.0",

--- a/tests/integration/test_migrations.py
+++ b/tests/integration/test_migrations.py
@@ -140,6 +140,21 @@ def produce_iva_docs_for_v2_mig() -> dict[str, list[dict[str, Any]]]:
     reverted_doc1["changed"] = reverted_date2
 
     doc2: dict[str, Any] = {
+        "_id": "c589bf1d-150a-49a0-adb7-599525249ff0",
+        "__metadata__": {
+            "deleted": True,
+            "published": False,
+            "correlation_id": "83f074de-05a9-45e8-b025-c0cefe369ec9",
+        },
+    }
+    migrated_doc2 = deepcopy(doc2)
+    migrated_doc2["_id"] = UUID("c589bf1d-150a-49a0-adb7-599525249ff0")
+    migrated_doc2["__metadata__"]["correlation_id"] = UUID(
+        "83f074de-05a9-45e8-b025-c0cefe369ec9"
+    )
+    reverted_doc2 = deepcopy(doc2)
+
+    doc3: dict[str, Any] = {
         "_id": "f4969771-630d-4c9b-b80d-a7ad69570e9b",
         "created": old_date1,
         "changed": old_date2,
@@ -155,22 +170,22 @@ def produce_iva_docs_for_v2_mig() -> dict[str, list[dict[str, Any]]]:
             "correlation_id": "3b4113a0-975a-486c-a37e-8cc0d7cc48a3",
         },
     }
-    migrated_doc2 = deepcopy(doc2)
-    migrated_doc2["_id"] = UUID("f4969771-630d-4c9b-b80d-a7ad69570e9b")
-    migrated_doc2["created"] = migrated_date1
-    migrated_doc2["changed"] = migrated_date2
-    migrated_doc2["user_id"] = UUID("587d7f49-b6ae-42d4-a163-58899b38915b")
-    migrated_doc2["__metadata__"]["correlation_id"] = UUID(
+    migrated_doc3 = deepcopy(doc3)
+    migrated_doc3["_id"] = UUID("f4969771-630d-4c9b-b80d-a7ad69570e9b")
+    migrated_doc3["created"] = migrated_date1
+    migrated_doc3["changed"] = migrated_date2
+    migrated_doc3["user_id"] = UUID("587d7f49-b6ae-42d4-a163-58899b38915b")
+    migrated_doc3["__metadata__"]["correlation_id"] = UUID(
         "3b4113a0-975a-486c-a37e-8cc0d7cc48a3"
     )
-    reverted_doc2 = deepcopy(doc2)
-    reverted_doc2["created"] = reverted_date1
-    reverted_doc2["changed"] = reverted_date2
+    reverted_doc3 = deepcopy(doc3)
+    reverted_doc3["created"] = reverted_date1
+    reverted_doc3["changed"] = reverted_date2
 
     return {
-        "old": [doc1, doc2],
-        "expected_migrated": [migrated_doc1, migrated_doc2],
-        "expected_reverted": [reverted_doc1, reverted_doc2],
+        "old": [doc1, doc2, doc3],
+        "expected_migrated": [migrated_doc1, migrated_doc2, migrated_doc3],
+        "expected_reverted": [reverted_doc1, reverted_doc2, reverted_doc3],
     }
 
 
@@ -271,10 +286,26 @@ def produce_user_docs_for_v2_mig() -> dict[str, list[dict[str, Any]]]:
     reverted_doc2["registration_date"] = reverted_date1
     reverted_doc2["status_change"]["change_date"] = reverted_date2
 
+    doc3: dict[str, Any] = {
+        "_id": "9abe34c3-3ee5-4e06-a87a-45001460c667",
+        "__metadata__": {
+            "deleted": True,
+            "published": True,
+            "correlation_id": "7ee3a091-1db1-44a8-aebe-a4552b173dfd",
+        },
+    }
+
+    migrated_doc3 = deepcopy(doc3)
+    migrated_doc3["_id"] = UUID("9abe34c3-3ee5-4e06-a87a-45001460c667")
+    migrated_doc3["__metadata__"]["correlation_id"] = UUID(
+        "7ee3a091-1db1-44a8-aebe-a4552b173dfd"
+    )
+    reverted_doc3 = deepcopy(doc3)
+
     return {
-        "old": [doc1, doc2],
-        "expected_migrated": [migrated_doc1, migrated_doc2],
-        "expected_reverted": [reverted_doc1, reverted_doc2],
+        "old": [doc1, doc2, doc3],
+        "expected_migrated": [migrated_doc1, migrated_doc2, migrated_doc3],
+        "expected_reverted": [reverted_doc1, reverted_doc2, reverted_doc3],
     }
 
 


### PR DESCRIPTION
Initial version of the V2Migration did not account for "deleted" outbox documents. "Deleted" outbox documents do not contain any of the normal payload fields. Instead, they only contain `_id` and `__metadata__`. This means that the migration lines that would modify payload fields in the manner `doc[field]` caused an error when migrating "deleted" outbox documents. 

This fix makes it so the migration does not attempt to migrate payload fields for documents with `__metadata__.deleted=False`.

Bumps version to `8.0.1`