### PR TITLE
Limit creation of IVAs

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,6 +376,7 @@ The service requires the following configuration parameters:
   ```
 
 - <a id="properties/log_traceback"></a>**`log_traceback`** *(boolean)*: Whether to include exception tracebacks in log messages. Default: `true`.
+- <a id="properties/max_ivas"></a>**`max_ivas`** *(integer)*: Maximum number of IVAs a user can create per day and in total. Default: `5`.
 - <a id="properties/max_iva_verification_attempts"></a>**`max_iva_verification_attempts`** *(integer)*: Maximum number of verification attempts for an IVA. Default: `10`.
 - <a id="properties/auto_send_iva_code_for_types"></a>**`auto_send_iva_code_for_types`** *(array)*: IVA types for which verification codes are sent automatically. Default: `["Phone"]`.
   - <a id="properties/auto_send_iva_code_for_types/items"></a>**Items**: Refer to *[#/$defs/IvaType](#%24defs/IvaType)*.

--- a/config_schema.json
+++ b/config_schema.json
@@ -443,6 +443,12 @@
       "title": "Log Traceback",
       "type": "boolean"
     },
+    "max_ivas": {
+      "default": 5,
+      "description": "Maximum number of IVAs a user can create per day and in total",
+      "title": "Max Ivas",
+      "type": "integer"
+    },
     "max_iva_verification_attempts": {
       "default": 10,
       "description": "Maximum number of verification attempts for an IVA",

--- a/example_config.yaml
+++ b/example_config.yaml
@@ -64,6 +64,7 @@ log_format: null
 log_level: DEBUG
 log_traceback: true
 max_iva_verification_attempts: 10
+max_ivas: 5
 migration_max_wait_sec: null
 migration_wait_sec: 10
 mongo_dsn: '**********'

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -582,6 +582,24 @@ components:
       - split_pattern
       title: MatchType
       type: string
+    PeriodCounter:
+      additionalProperties: false
+      description: Counter for user-related actions across time periods.
+      properties:
+        count:
+          description: Count value for the period
+          title: Count
+          type: integer
+        date:
+          description: Timestamp for which the counter is valid
+          format: date-time
+          title: Date
+          type: string
+      required:
+      - date
+      - count
+      title: PeriodCounter
+      type: object
     StatusChange:
       additionalProperties: false
       description: Details of a status change
@@ -732,6 +750,11 @@ components:
           format: uuid4
           title: Id
           type: string
+        ivas_created_today:
+          anyOf:
+          - $ref: '#/components/schemas/PeriodCounter'
+          - type: 'null'
+          description: Number of IVAs that have been created today
         name:
           description: Full name of the user
           examples:
@@ -891,6 +914,11 @@ components:
           format: uuid4
           title: Id
           type: string
+        ivas_created_today:
+          anyOf:
+          - $ref: '#/components/schemas/PeriodCounter'
+          - type: 'null'
+          description: Number of IVAs that have been created today
         name:
           description: Full name of the user
           examples:
@@ -2212,6 +2240,8 @@ paths:
           description: The user was not found.
         '422':
           description: Validation error in submitted user identification.
+        '429':
+          description: Too many IVAs have been created.
       security:
       - HTTPBearer: []
       summary: Create a new IVA

--- a/src/auth_service/user_registry/core/config.py
+++ b/src/auth_service/user_registry/core/config.py
@@ -31,6 +31,11 @@ __all__ = ["INITIAL_USER_STATUS", "UserRegistryConfig"]
 class UserRegistryConfig(BaseSettings):
     """Configuration for the user registry."""
 
+    max_ivas: int = Field(
+        default=5,
+        description="Maximum number of IVAs a user can create per day and in total",
+    )
+
     max_iva_verification_attempts: int = Field(
         default=10, description="Maximum number of verification attempts for an IVA"
     )

--- a/src/auth_service/user_registry/models/users.py
+++ b/src/auth_service/user_registry/models/users.py
@@ -23,7 +23,23 @@ from pydantic import UUID4, EmailStr, Field
 
 from . import BaseDto
 
-__all__ = ["StatusChange", "User", "UserData", "UserStatus", "UserWithRoles"]
+__all__ = [
+    "PeriodCounter",
+    "StatusChange",
+    "User",
+    "UserData",
+    "UserStatus",
+    "UserWithRoles",
+]
+
+
+class PeriodCounter(BaseDto):
+    """Counter for user-related actions across time periods."""
+
+    date: UTCDatetime = Field(
+        default=..., description="Timestamp for which the counter is valid"
+    )
+    count: int = Field(default=..., description="Count value for the period")
 
 
 class UserStatus(StrEnum):
@@ -106,6 +122,10 @@ class UserAutomaticData(BaseDto):
 
     status_change: StatusChange | None = Field(
         default=None, description="Last status change"
+    )
+
+    ivas_created_today: PeriodCounter | None = Field(
+        default=None, description="Number of IVAs that have been created today"
     )
 
     active_submissions: list[str] = Field(

--- a/src/auth_service/user_registry/ports/registry.py
+++ b/src/auth_service/user_registry/ports/registry.py
@@ -96,6 +96,13 @@ class UserRegistryPort(ABC):
             message = f"Could not create IVA for user with ID {user_id}"
             super().__init__(message)
 
+    class TooManyIVAsError(UserRegistryIvaError):
+        """Raised when too many IVAs have been created by the user."""
+
+        def __init__(self, *, user_id: UUID4):
+            message = f"Too many IVAs created by user with ID {user_id}"
+            super().__init__(message)
+
     class IvaRetrievalError(UserRegistryIvaError):
         """Raised when IVAs cannot be retrieved from the database."""
 
@@ -252,7 +259,8 @@ class UserRegistryPort(ABC):
 
         Returns the internal ID of the newly createdIVA.
 
-        May raise a UserDoesNotExistError or an IvaCreationError.
+        May raise a UserDoesNotExistError, IvaCreationError or TooManyIVAsError
+        in case too many IVAs have been created by the user today or in total.
         """
         ...
 

--- a/src/auth_service/user_registry/rest/router.py
+++ b/src/auth_service/user_registry/rest/router.py
@@ -413,6 +413,7 @@ async def get_user_ivas(
         403: {"description": "Not authorized to create this IVA."},
         404: {"description": "The user was not found."},
         422: {"description": "Validation error in submitted user identification."},
+        429: {"description": "Too many IVAs have been created."},
     },
     status_code=201,
 )
@@ -443,8 +444,12 @@ async def post_user_iva(
         raise HTTPException(
             status_code=404, detail="The user was not found."
         ) from error
-    except user_registry.IvaRetrievalError as error:
-        raise HTTPException(status_code=500, detail="Cannot create IVA") from error
+    except user_registry.TooManyIVAsError as error:
+        raise HTTPException(
+            status_code=429, detail="Too many IVAs have been created."
+        ) from error
+    except user_registry.IvaCreationError as error:
+        raise HTTPException(status_code=500, detail="Cannot create IVA.") from error
     return IvaId(id=id_)
 
 


### PR DESCRIPTION
Since user accounts are activated automatically, we want to limit the amount of IVAs a user can create. We check that:

- the users do not create duplicate IVAs
- the users do not create more than 5 IVAs in total
- the users do not create more than 5 IVAs per day (otherwise they could delete and recreate ad libitum)

The maximum number of 5 IVAs is configurable though.

I think it is not worthwhile to differentiate the limits for total and daily numbers since this is just a sanity check and the numbers should be roughly similar anyway.

