### PR TITLE
Fix production dockerfile

### DIFF
--- a/.pyproject_generation/pyproject_custom.toml
+++ b/.pyproject_generation/pyproject_custom.toml
@@ -1,6 +1,6 @@
 [project]
 name = "auth_service"
-version = "8.3.0"
+version = "8.3.1"
 description = "Authentication adapter and services used for the GHGA data portal"
 dependencies = [
     "ghga-event-schemas~=11.1.1",

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,9 @@ RUN apk update && \
 WORKDIR /service
 COPY --from=builder /service/lock/requirements.txt /service
 RUN pip install --no-cache-dir --no-deps -r requirements.txt
+# Binaries that are needed at runtime
+RUN mkdir -p /opt/runtime-bin
+RUN cp /usr/local/bin/opentelemetry-instrument /opt/runtime-bin/ 2>/dev/null || true
 
 # RUNNER: a container to run the service
 FROM base AS runner
@@ -40,9 +43,9 @@ RUN adduser -D appuser
 WORKDIR /service
 RUN rm -rf /usr/local/lib/python3.13
 COPY --from=dep-builder /usr/local/lib/python3.13 /usr/local/lib/python3.13
+COPY --from=dep-builder /opt/runtime-bin/ /usr/local/bin/
 COPY --from=builder /service/dist/ /service
-RUN pip install --no-cache-dir --no-deps *.whl && \
-    rm *.whl
+RUN pip install --no-cache-dir --no-deps *.whl && rm *.whl
 # switch to non-root user
 WORKDIR /home/appuser
 USER appuser

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -13,8 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
-## creating building container
+# creating building container
 FROM python:3.13-slim-trixie AS builder
 # update and install dependencies
 RUN apt-get update && apt-get upgrade -y
@@ -40,8 +39,7 @@ COPY --from=builder /service/lock/requirements.txt /service
 RUN pip install --no-cache-dir --no-deps -r requirements.txt && \
     rm requirements.txt
 COPY --from=builder /service/dist/ /service
-RUN pip install --no-cache-dir --no-deps *.whl && \
-    rm *.whl
+RUN pip install --no-cache-dir --no-deps *.whl && rm *.whl
 # switch to non-root user
 WORKDIR /home/appuser
 USER appuser

--- a/README.md
+++ b/README.md
@@ -47,13 +47,13 @@ We recommend using the provided Docker container.
 
 A pre-built version is available on [Docker Hub](https://hub.docker.com/repository/docker/ghga/auth-service):
 ```bash
-docker pull ghga/auth-service:8.3.0
+docker pull ghga/auth-service:8.3.1
 ```
 
 Or you can build the container yourself from the [`./Dockerfile`](./Dockerfile):
 ```bash
 # Execute in the repo's root dir:
-docker build -t ghga/auth-service:8.3.0 .
+docker build -t ghga/auth-service:8.3.1 .
 ```
 
 For production-ready deployment, we recommend using Kubernetes.
@@ -61,7 +61,7 @@ However for simple use cases, you could execute the service using docker
 on a single server:
 ```bash
 # The entrypoint is pre-configured:
-docker run -p 8080:8080 ghga/auth-service:8.3.0 --help
+docker run -p 8080:8080 ghga/auth-service:8.3.1 --help
 ```
 
 If you prefer not to use containers, you may install the service from source:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1007,7 +1007,7 @@ info:
   license:
     name: Apache 2.0
   title: Auth Service API
-  version: 8.3.0
+  version: 8.3.1
 openapi: 3.1.0
 paths:
   /download-access/grants:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Intended Audience :: Developers",
 ]
 name = "auth_service"
-version = "8.3.0"
+version = "8.3.1"
 description = "Authentication adapter and services used for the GHGA data portal"
 dependencies = [
     "ghga-event-schemas~=11.1.1",


### PR DESCRIPTION
When updating from the template, the telemetry support was accidentally removed from the production dockerfile since it was not included in the template (now it is).